### PR TITLE
Fix/cele 72 post merge issues

### DIFF
--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -168,8 +168,8 @@ const EMStackViewer = () => {
     });
 
     // set map zoom to the minimum zoom possible
-    const minZoomAvailable = tilegrid.getMinZoom()
-    map.getView().setZoom(minZoomAvailable)
+    const minZoomAvailable = tilegrid.getMinZoom();
+    map.getView().setZoom(minZoomAvailable);
 
     const ringEM = new SlidingRing({
       cacheSize: ringSize,
@@ -256,16 +256,16 @@ const EMStackViewer = () => {
 
   const onControlZoomIn = () => {
     if (!mapRef.current) return;
-    const view = mapRef.current.getView()
-    const targetZoom = view.getZoom() + 1
-    view.setZoom(view.getConstrainedZoom(targetZoom, 1))
+    const view = mapRef.current.getView();
+    const targetZoom = view.getZoom() + 1;
+    view.setZoom(view.getConstrainedZoom(targetZoom, 1));
   };
 
   const onControlZoomOut = () => {
     if (!mapRef.current) return;
-    const view = mapRef.current.getView()
-    const targetZoom = view.getZoom() - 1
-    view.setZoom(view.getConstrainedZoom(targetZoom, -1))
+    const view = mapRef.current.getView();
+    const targetZoom = view.getZoom() - 1;
+    view.setZoom(view.getConstrainedZoom(targetZoom, -1));
   };
 
   const onResetView = () => {
@@ -275,8 +275,8 @@ const EMStackViewer = () => {
     const center = getCenter(extent);
     view.setCenter(center);
 
-    const minZoomAvailable = tilegrid.getMinZoom()
-    view.setZoom(minZoomAvailable)
+    const minZoomAvailable = tilegrid.getMinZoom();
+    view.setZoom(minZoomAvailable);
   };
 
   const onPrint = () => {

--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -161,14 +161,15 @@ const EMStackViewer = () => {
         projection: projection,
         center: getCenter(extent),
         extent: extent,
-        zoom: 1,
-        minZoom: 1, // mitigates blanc tiles on reset view (EM layer doesn't have tiles at zoom 0)
-        maxZoom: 5,
-        resolutions: tilegrid.getResolutions(),
+        resolutions: tilegrid.getResolutions(), // forces view zoom options
       }),
       controls: [scale],
       interactions: interactions,
     });
+
+    // set map zoom to the minimum zoom possible
+    const minZoomAvailable = tilegrid.getMinZoom()
+    map.getView().setZoom(minZoomAvailable)
 
     const ringEM = new SlidingRing({
       cacheSize: ringSize,
@@ -255,20 +256,27 @@ const EMStackViewer = () => {
 
   const onControlZoomIn = () => {
     if (!mapRef.current) return;
-    mapRef.current.getView().adjustZoom(1);
+    const view = mapRef.current.getView()
+    const targetZoom = view.getZoom() + 1
+    view.setZoom(view.getConstrainedZoom(targetZoom, 1))
   };
 
   const onControlZoomOut = () => {
     if (!mapRef.current) return;
-    mapRef.current.getView().adjustZoom(-1);
+    const view = mapRef.current.getView()
+    const targetZoom = view.getZoom() - 1
+    view.setZoom(view.getConstrainedZoom(targetZoom, -1))
   };
 
   const onResetView = () => {
     if (!mapRef.current) return;
     const view = mapRef.current.getView();
+
     const center = getCenter(extent);
     view.setCenter(center);
-    view.setZoom(1);
+
+    const minZoomAvailable = tilegrid.getMinZoom()
+    view.setZoom(minZoomAvailable)
   };
 
   const onPrint = () => {

--- a/applications/visualizer/frontend/src/components/viewers/EM/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/SceneControls.tsx
@@ -1,4 +1,4 @@
-import { FileDownloadOutlined, HomeOutlined, TextsmsOutlined } from "@mui/icons-material";
+import { FileDownloadOutlined, HomeOutlined } from "@mui/icons-material";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import { Box, Divider, IconButton } from "@mui/material";

--- a/applications/visualizer/frontend/src/components/viewers/EM/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/SceneControls.tsx
@@ -45,12 +45,12 @@ function SceneControls({ onZoomIn, onResetView, onZoomOut, onPrint }: ScaleContr
         </IconButton>
       </Tooltip>
       <Divider />
-      <Tooltip title="Add comment" placement="right-start">
+      {/* <Tooltip title="Add comment" placement="right-start">
         <IconButton>
           <TextsmsOutlined />
         </IconButton>
       </Tooltip>
-      <Divider />
+      <Divider /> */}
       <Tooltip title="Download image" placement="right-start">
         <IconButton onClick={onPrint}>
           <FileDownloadOutlined />


### PR DESCRIPTION
- [x] _Cannot zoom out over a certain limit, this needs to be improved/fixed_
The reset view button and minimum zoom was hardcoded to 1 due to openlayers rendering blanc tiles on zoom 0.
Seem like the underlying problem was related to the tile grid. The tile grid minimum zoom is a fractional number that was causing issues loading tiles when the map canvas was to small on minzoom.
Now the EM viewer takes in consideration the minimum zoom for the tile grid, which seems to have fixed this issue, allowing the zoom to be the furthers possible.
> [!NOTE]  
> The underlying changes also fix an unnoticed bug where by clicking on zoom out and zoom in button in min and max zooms respectively, it would overshoot the allowed zooms. Trying to go in the reverse direction would cause the click to not have a visible effect until an equal amount of click was performed. It seems to be an openlayers behavior related to the fractional zooms.
- [ ] _cannot download the image_
Wasn't able to reproduce the issue. Has been tested in Safari, Firefox and Chrome on Darwin and Linux. Further context is required.
- [x] _remove/hide the add comment button since annotations won’t be allowed in this SOW_