### PR TITLE
Fix loop edges colors

### DIFF
--- a/applications/visualizer/frontend/src/helpers/twoD/twoDHelpers.ts
+++ b/applications/visualizer/frontend/src/helpers/twoD/twoDHelpers.ts
@@ -12,16 +12,13 @@ export const createEdge = (id: string, conn: Connection, workspace: Workspace, i
   const label = createEdgeLabel(workspace, synapses);
   const longLabel = createEdgeLongLabel(workspace, synapses);
 
-  let annotationClasses: string[] = [];
+  const annotationClasses: string[] = annotations.map((annotation) => annotationLegend[annotation]?.id).filter(Boolean);
 
-  if (includeAnnotations) {
-    annotationClasses = annotations.map((annotation) => annotationLegend[annotation]?.id).filter(Boolean);
-    if (annotationClasses.length === 0) {
-      annotationClasses.push(annotationLegend.notClassified.id);
-    }
-  } else {
-    annotationClasses.push(conn.type);
+  if (includeAnnotations && annotationClasses.length === 0) {
+    annotationClasses.push(annotationLegend.notClassified.id);
   }
+
+  annotationClasses.push(conn.type);
 
   const classes = annotationClasses.join(" ");
   return {

--- a/applications/visualizer/frontend/src/theme/twoDStyles.ts
+++ b/applications/visualizer/frontend/src/theme/twoDStyles.ts
@@ -115,15 +115,6 @@ const ELECTRICAL_STYLE = [
       "source-arrow-shape": "tee",
     },
   },
-  {
-    selector: ".not_classified:loop",
-    css: {
-      "target-arrow-shape": "tee",
-      "source-arrow-shape": "tee",
-      "source-arrow-color": "#228B22",
-      "target-arrow-color": "#228B22",
-    },
-  },
 ];
 
 const OPEN_GROUP_STYLE = {

--- a/applications/visualizer/frontend/src/theme/twoDStyles.ts
+++ b/applications/visualizer/frontend/src/theme/twoDStyles.ts
@@ -115,6 +115,15 @@ const ELECTRICAL_STYLE = [
       "source-arrow-shape": "tee",
     },
   },
+  {
+    selector: ".not_classified:loop",
+    css: {
+      "target-arrow-shape": "tee",
+      "source-arrow-shape": "tee",
+      "source-arrow-color": "#228B22",
+      "target-arrow-color": "#228B22",
+    },
+  },
 ];
 
 const OPEN_GROUP_STYLE = {
@@ -258,6 +267,7 @@ const ANNOTATION_STYLES = Object.entries(annotationLegend).map(([, { id, color }
   style: {
     "line-color": color,
     "target-arrow-color": color,
+    "sources-arrow-color": color,
   },
 }));
 

--- a/applications/visualizer/frontend/src/theme/twoDStyles.ts
+++ b/applications/visualizer/frontend/src/theme/twoDStyles.ts
@@ -116,7 +116,7 @@ const ELECTRICAL_STYLE = [
     },
   },
   {
-    selector: ".not_classified:loop",
+    selector: ".electrical.not_classified:loop",
     css: {
       "target-arrow-shape": "tee",
       "source-arrow-shape": "tee",

--- a/applications/visualizer/frontend/src/theme/twoDStyles.ts
+++ b/applications/visualizer/frontend/src/theme/twoDStyles.ts
@@ -115,6 +115,15 @@ const ELECTRICAL_STYLE = [
       "source-arrow-shape": "tee",
     },
   },
+  {
+    selector: ".not_classified:loop",
+    css: {
+      "target-arrow-shape": "tee",
+      "source-arrow-shape": "tee",
+      "source-arrow-color": "#228B22",
+      "target-arrow-color": "#228B22",
+    },
+  },
 ];
 
 const OPEN_GROUP_STYLE = {


### PR DESCRIPTION
- **current issue**
when enabling the types of connections from viewer settings, the self connected edges loose the desired source/target arrow shape/color because of loosing the right className for the edge

<img width="461" alt="Screenshot 2024-09-13 at 4 15 58 PM" src="https://github.com/user-attachments/assets/d728d6db-1225-4e98-ad69-5bbbb3541a37">
 

- **solution**
making sure that the edge classes always has the `conn.type` class which has all styles we need for each type of edges, and added some extra style for `.electrical.not_classified:loop` to make sure it gets the right style when enabling the types of connections

<img width="621" alt="Screenshot 2024-09-13 at 4 53 51 PM" src="https://github.com/user-attachments/assets/edec8bf6-be74-4195-945f-daf98aa41055">
