### PR TITLE
refactor screenshot code

### DIFF
--- a/applications/visualizer/frontend/package.json
+++ b/applications/visualizer/frontend/package.json
@@ -31,6 +31,7 @@
     "cytoscape-dagre": "^2.5.0",
     "cytoscape-fcose": "^2.2.0",
     "file-saver": "^2.0.5",
+    "html-to-image": "^1.11.11",
     "html2canvas": "^1.4.1",
     "ol": "^9.1.0",
     "pako": "^2.1.0",

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Recorder.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Recorder.ts
@@ -17,7 +17,7 @@ export class Recorder {
     this.setupMediaRecorder(mediaRecorderOptions);
     this.recordedBlobs = [];
     this.blobOptions = blobOptions;
-    this.ctx = canvas.getContext("webgl", { alpha: true, antialias: true, preserveDrawingBuffer: true });
+    this.ctx = canvas.getContext("webgl");
   }
 
   handleDataAvailable(event) {

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Recorder.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Recorder.ts
@@ -1,0 +1,115 @@
+import { formatDate } from "../../../helpers/utils.ts";
+export class Recorder {
+  private mediaRecorder: MediaRecorder | null = null;
+  private recordedBlobs: Blob[] = [];
+  private stream: MediaStream;
+  private ctx: WebGLRenderingContext;
+  // @ts-ignore
+  private options: { mediaRecorderOptions?: MediaRecorderOptions; blobOptions?: BlobPropertyBag } = {
+    mediaRecorderOptions: { mimeType: "video/webm" },
+    blobOptions: { type: "video/webm" },
+  };
+  private blobOptions: BlobPropertyBag = { type: "video/webm" };
+
+  constructor(canvas: HTMLCanvasElement, recorderOptions: { mediaRecorderOptions?: MediaRecorderOptions; blobOptions?: BlobPropertyBag }) {
+    this.stream = canvas.captureStream();
+    const { mediaRecorderOptions, blobOptions } = recorderOptions;
+    this.setupMediaRecorder(mediaRecorderOptions);
+    this.recordedBlobs = [];
+    this.blobOptions = blobOptions;
+    this.ctx = canvas.getContext("webgl", { alpha: true, antialias: true, preserveDrawingBuffer: true });
+  }
+
+  handleDataAvailable(event) {
+    if (event.data && event.data.size > 0) {
+      this.recordedBlobs.push(event.data);
+    }
+  }
+
+  setupMediaRecorder(options) {
+    let error = "";
+
+    if (options == null) {
+      options = { mimeType: "video/webm" };
+    }
+    let mediaRecorder;
+    try {
+      mediaRecorder = new MediaRecorder(this.stream, options);
+    } catch (e0) {
+      error = `Unable to create MediaRecorder with options Object: ${e0}`;
+      try {
+        options = { mimeType: "video/webm,codecs=vp9" };
+        mediaRecorder = new MediaRecorder(this.stream, options);
+      } catch (e1) {
+        error = `Unable to create MediaRecorder with options Object: ${e1}`;
+        try {
+          options = { mimeType: "video/webm,codecs=vp8" }; // Chrome 47
+          mediaRecorder = new MediaRecorder(this.stream, options);
+        } catch (e2) {
+          error =
+            "MediaRecorder is not supported by this browser.\n\n" +
+            "Try Firefox 29 or later, or Chrome 47 or later, " +
+            "with Enable experimental Web Platform features enabled from chrome://flags." +
+            `Exception while creating MediaRecorder: ${e2}`;
+        }
+      }
+    }
+
+    if (!mediaRecorder) {
+      throw new Error(error);
+    }
+
+    mediaRecorder.ondataavailable = (evt) => this.handleDataAvailable(evt);
+    mediaRecorder.onstart = () => this.animationLoop();
+
+    this.mediaRecorder = mediaRecorder;
+    this.options = options;
+    if (!this.blobOptions) {
+      const { mimeType } = options;
+      this.blobOptions = { type: mimeType };
+    }
+  }
+
+  startRecording() {
+    this.recordedBlobs = [];
+    this.mediaRecorder.start(100);
+  }
+
+  stopRecording(options) {
+    this.mediaRecorder.stop();
+    return this.getRecordingBlob(options);
+  }
+
+  download(filename, options) {
+    if (!filename) {
+      filename = `CanvasRecording_${formatDate(new Date())}.webm`;
+    }
+    const blob = this.getRecordingBlob(options);
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.style.display = "none";
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    setTimeout(() => {
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    }, 100);
+    return blob;
+  }
+
+  getRecordingBlob(options) {
+    if (!options) {
+      options = this.blobOptions;
+    }
+    return new Blob(this.recordedBlobs, options);
+  }
+
+  animationLoop() {
+    this.ctx.drawArrays(this.ctx.POINTS, 0, 0);
+    if (this.mediaRecorder.state !== "inactive") {
+      requestAnimationFrame(this.animationLoop);
+    }
+  }
+}

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Recorder.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Recorder.ts
@@ -1,4 +1,5 @@
 import { formatDate } from "../../../helpers/utils.ts";
+import { GlobalError } from "../../../models/Error.ts";
 export class Recorder {
   private mediaRecorder: MediaRecorder | null = null;
   private recordedBlobs: Blob[] = [];
@@ -56,7 +57,7 @@ export class Recorder {
     }
 
     if (!mediaRecorder) {
-      throw new Error(error);
+      throw new GlobalError(error);
     }
 
     mediaRecorder.ondataavailable = (evt) => this.handleDataAvailable(evt);

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -9,8 +9,18 @@ import CustomFormControlLabel from "./CustomFormControlLabel.tsx";
 
 const { gray500 } = vars;
 
-function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, handleScreenshot }) {
+function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, handleScreenshot, startRecording, stopRecording }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+
+  const handleRecordClick = () => {
+    if (isRecording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+    setIsRecording(!isRecording);
+  };
 
   const open = Boolean(anchorEl);
   const id = open ? "settings-popover" : undefined;
@@ -123,9 +133,13 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, handleSc
           <PlayArrowOutlined />
         </IconButton>
       </Tooltip>
-      <Tooltip title="Record viewer" placement="right-start">
-        <IconButton>
-          <RadioButtonCheckedOutlined />
+      <Tooltip title={isRecording ? "Stop recording" : "Record viewer"} placement="right-start">
+        <IconButton onClick={handleRecordClick}>
+          <RadioButtonCheckedOutlined
+            sx={{
+              color: isRecording ? "red" : "inherit",
+            }}
+          />
         </IconButton>
       </Tooltip>
       <Tooltip title="Download graph" placement="right-start">

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -6,10 +6,12 @@ import Tooltip from "@mui/material/Tooltip";
 import { useState } from "react";
 import { vars } from "../../../theme/variables.ts";
 import CustomFormControlLabel from "./CustomFormControlLabel.tsx";
+import { Recorder } from "./Recorder.ts";
+import { downloadScreenshot } from "./Screenshoter.ts";
 
 const { gray500 } = vars;
 
-function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, handleScreenshot, startRecording, stopRecording }) {
+function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorderRef }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [isRecording, setIsRecording] = useState(false);
 
@@ -30,6 +32,31 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, handleSc
 
   const handleCloseSettings = () => {
     setAnchorEl(null);
+  };
+
+  const handleScreenshot = () => {
+    if (cameraControlRef.current) {
+      downloadScreenshot(document.getElementsByTagName("canvas")[0], 0.95, { width: 3840, height: 2160 }, 1, () => true, "screenshot.png");
+    }
+  };
+
+  const startRecording = () => {
+    if (recorderRef.current === null) {
+      const canvas = document.getElementsByTagName("canvas")[0];
+      recorderRef.current = new Recorder(canvas, {
+        mediaRecorderOptions: { mimeType: "video/webm" },
+        blobOptions: { type: "video/webm" },
+      });
+      recorderRef.current.startRecording();
+    }
+  };
+
+  const stopRecording = async () => {
+    if (recorderRef.current) {
+      recorderRef.current.stopRecording({ type: "video/webm" });
+      recorderRef.current.download("CanvasRecording.webm", { type: "video/webm" });
+      recorderRef.current = null;
+    }
   };
 
   return (

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -71,7 +71,7 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
   const stopRecording = async () => {
     if (recorderRef.current) {
       recorderRef.current.stopRecording({ type: "video/webm" });
-      recorderRef.current.download(workspace.name + ".webm", { type: "video/webm" });
+      recorderRef.current.download(`${workspace.name}.webm`, { type: "video/webm" });
       recorderRef.current = null;
     }
   };

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -7,11 +7,10 @@ import { useRef, useState } from "react";
 import { vars } from "../../../theme/variables.ts";
 import CustomFormControlLabel from "./CustomFormControlLabel.tsx";
 import { Recorder } from "./Recorder.ts";
-import { downloadScreenshot } from "./Screenshoter.ts";
 
 const { gray500 } = vars;
 
-function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorderRef }) {
+function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorderRef, handleScreenshot }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const rotateAnimationRef = useRef<number | null>(null);
   const [isRotating, setIsRotating] = useState(false);
@@ -56,13 +55,6 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
 
     setIsRotating(!isRotating);
   };
-
-  const handleScreenshot = () => {
-    if (cameraControlRef.current) {
-      downloadScreenshot(document.getElementsByTagName("canvas")[0], 0.95, { width: 3840, height: 2160 }, 1, () => true, "screenshot.png");
-    }
-  };
-
   const startRecording = () => {
     if (recorderRef.current === null) {
       const canvas = document.getElementsByTagName("canvas")[0];

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -4,6 +4,7 @@ import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import { Box, Divider, IconButton, Popover, Typography } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import { useRef, useState } from "react";
+import { useSelectedWorkspace } from "../../../hooks/useSelectedWorkspace.ts";
 import { vars } from "../../../theme/variables.ts";
 import CustomFormControlLabel from "./CustomFormControlLabel.tsx";
 import { Recorder } from "./Recorder.ts";
@@ -11,6 +12,7 @@ import { Recorder } from "./Recorder.ts";
 const { gray500 } = vars;
 
 function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorderRef, handleScreenshot }) {
+  const workspace = useSelectedWorkspace();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const rotateAnimationRef = useRef<number | null>(null);
   const [isRotating, setIsRotating] = useState(false);
@@ -69,7 +71,7 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
   const stopRecording = async () => {
     if (recorderRef.current) {
       recorderRef.current.stopRecording({ type: "video/webm" });
-      recorderRef.current.download("CanvasRecording.webm", { type: "video/webm" });
+      recorderRef.current.download(workspace.name + ".webm", { type: "video/webm" });
       recorderRef.current = null;
     }
   };

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -1,16 +1,26 @@
-import { GetAppOutlined, HomeOutlined, PlayArrowOutlined, RadioButtonCheckedOutlined, SettingsOutlined, TonalityOutlined } from "@mui/icons-material";
+import {
+  DarkModeOutlined,
+  GetAppOutlined,
+  HomeOutlined,
+  PlayArrowOutlined,
+  RadioButtonCheckedOutlined,
+  SettingsOutlined,
+  TonalityOutlined,
+  WbSunnyOutlined,
+} from "@mui/icons-material";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import ZoomOutIcon from "@mui/icons-material/ZoomOut";
 import { Box, Divider, IconButton, Popover, Typography } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import { useRef, useState } from "react";
+import { DARK_SCENE_BACKGROUND, LIGHT_SCENE_BACKGROUND } from "../../../settings/threeDSettings.ts";
 import { vars } from "../../../theme/variables.ts";
 import CustomFormControlLabel from "./CustomFormControlLabel.tsx";
 import { Recorder } from "./Recorder.ts";
 
 const { gray500 } = vars;
 
-function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorderRef, handleScreenshot }) {
+function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorderRef, handleScreenshot, sceneColor, setSceneColor }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const rotateAnimationRef = useRef<number | null>(null);
   const [isRotating, setIsRotating] = useState(false);
@@ -74,6 +84,14 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
     }
   };
 
+  const handleSwichMode = () => {
+    if (sceneColor === LIGHT_SCENE_BACKGROUND) {
+      setSceneColor(DARK_SCENE_BACKGROUND);
+    } else {
+      setSceneColor(LIGHT_SCENE_BACKGROUND);
+    }
+  };
+
   return (
     <Box
       sx={{
@@ -83,11 +101,24 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
         position: "absolute",
         top: ".5rem",
         left: ".5rem",
-        backgroundColor: "#fff",
+        backgroundColor: sceneColor === LIGHT_SCENE_BACKGROUND ? "white" : "#393937",
         borderRadius: "0.5rem",
-        border: "1px solid #ECECE9",
+        border: `1px solid ${sceneColor === LIGHT_SCENE_BACKGROUND ? "#ECECE9" : "#393937"}`,
         boxShadow: "0px 1px 2px 0px rgba(16, 24, 40, 0.05)",
         padding: "0.25rem",
+
+        "& .MuiDivider-root": {
+          borderColor: sceneColor === LIGHT_SCENE_BACKGROUND ? "#ECECE9" : "#535350",
+        },
+
+        "& .MuiButtonBase-root": {
+          "&:hover": {
+            backgroundColor: sceneColor === LIGHT_SCENE_BACKGROUND ? "#F6F5F4" : "#535350",
+          },
+          "& .MuiSvgIcon-root": {
+            color: sceneColor === LIGHT_SCENE_BACKGROUND ? "#757570" : "#ECECE9",
+          },
+        },
       }}
     >
       <Tooltip title="Change settings" placement="right-start">
@@ -140,6 +171,9 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
           <TonalityOutlined />
         </IconButton>
       </Tooltip>
+      <Tooltip title={sceneColor === LIGHT_SCENE_BACKGROUND ? "Switch to dark mode" : "Switch to light mode"} placement="right-start">
+        <IconButton onClick={handleSwichMode}>{sceneColor === LIGHT_SCENE_BACKGROUND ? <DarkModeOutlined /> : <WbSunnyOutlined />}</IconButton>
+      </Tooltip>
       <Divider />
       <Tooltip title="Zoom in" placement="right-start">
         <IconButton
@@ -178,7 +212,7 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
         <IconButton onClick={handleRecordClick}>
           <RadioButtonCheckedOutlined
             sx={{
-              color: isRecording ? "red" : "inherit",
+              color: isRecording ? "red !important" : "inherit",
             }}
           />
         </IconButton>

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -9,7 +9,7 @@ import CustomFormControlLabel from "./CustomFormControlLabel.tsx";
 
 const { gray500 } = vars;
 
-function SceneControls({ cameraControlRef, isWireframe, setIsWireframe }) {
+function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, handleScreenshot }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const open = Boolean(anchorEl);
@@ -129,7 +129,7 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe }) {
         </IconButton>
       </Tooltip>
       <Tooltip title="Download graph" placement="right-start">
-        <IconButton>
+        <IconButton onClick={handleScreenshot}>
           <GetAppOutlined />
         </IconButton>
       </Tooltip>

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
@@ -1,16 +1,6 @@
 import * as htmlToImage from "html-to-image";
+import { formatDate } from "../../../helpers/utils.ts";
 
-export function formatDate(d) {
-  return `${d.getFullYear()}${d.getMonth() + 1}${d.getDate()}-${pad(d.getHours(), 2)}${pad(d.getMinutes(), 2)}${pad(d.getSeconds(), 2)}`;
-}
-
-function pad(num, size) {
-  let s = num + "";
-  while (s.length < size) {
-    s = "0" + s;
-  }
-  return s;
-}
 function getOptions(htmlElement, targetResolution, quality, pixelRatio, filter) {
   const resolution = getResolutionFixedRatio(htmlElement, targetResolution);
   return {
@@ -32,7 +22,6 @@ export function downloadScreenshot(
 ) {
   const options = getOptions(htmlElement, targetResolution, quality, pixelRatio, filter);
 
-  // Use `toBlob` to capture the canvas content as a blob
   htmlToImage.toBlob(htmlElement, options).then((blob) => {
     const link = document.createElement("a");
     link.download = filename;
@@ -46,7 +35,7 @@ function getResolutionFixedRatio(htmlElement, target) {
     height: htmlElement.clientHeight,
     width: htmlElement.clientWidth,
   };
-  // if height is closer
+
   if ((Math.abs(target.width - current.width) * 9) / 16 > Math.abs(target.height - current.height)) {
     return {
       height: target.height,

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { GlobalError } from "../../../models/Error.ts";
 
 function getResolutionFixedRatio(htmlElement: HTMLElement, target: { width: number; height: number }) {
   const current = {
@@ -59,6 +60,6 @@ export function downloadScreenshot(
 
     tempRenderer.dispose();
   } catch (e) {
-    console.error("Error saving image:", e);
+    throw new GlobalError(`Error saving image: ${e}`);
   }
 }

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
@@ -1,0 +1,60 @@
+import * as htmlToImage from "html-to-image";
+
+export function formatDate(d) {
+  return `${d.getFullYear()}${d.getMonth() + 1}${d.getDate()}-${pad(d.getHours(), 2)}${pad(d.getMinutes(), 2)}${pad(d.getSeconds(), 2)}`;
+}
+
+function pad(num, size) {
+  let s = num + "";
+  while (s.length < size) {
+    s = "0" + s;
+  }
+  return s;
+}
+function getOptions(htmlElement, targetResolution, quality, pixelRatio, filter) {
+  const resolution = getResolutionFixedRatio(htmlElement, targetResolution);
+  return {
+    quality: quality,
+    canvasWidth: resolution.width,
+    canvasHeight: resolution.height,
+    pixelRatio: pixelRatio,
+    filter: filter,
+  };
+}
+
+export function downloadScreenshot(
+  htmlElement,
+  quality = 0.95,
+  targetResolution = { width: 3840, height: 2160 },
+  pixelRatio = 1,
+  filter = () => true,
+  filename = `Canvas_${formatDate(new Date())}.png`,
+) {
+  const options = getOptions(htmlElement, targetResolution, quality, pixelRatio, filter);
+
+  // Use `toBlob` to capture the canvas content as a blob
+  htmlToImage.toBlob(htmlElement, options).then((blob) => {
+    const link = document.createElement("a");
+    link.download = filename;
+    link.href = window.URL.createObjectURL(blob);
+    link.click();
+  });
+}
+
+function getResolutionFixedRatio(htmlElement, target) {
+  const current = {
+    height: htmlElement.clientHeight,
+    width: htmlElement.clientWidth,
+  };
+  // if height is closer
+  if ((Math.abs(target.width - current.width) * 9) / 16 > Math.abs(target.height - current.height)) {
+    return {
+      height: target.height,
+      width: Math.round((current.width * target.height) / current.height),
+    };
+  }
+  return {
+    height: Math.round((current.height * target.width) / current.width),
+    width: target.width,
+  };
+}

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/Screenshoter.ts
@@ -31,6 +31,7 @@ export function downloadScreenshot(
   canvasRef: React.RefObject<HTMLCanvasElement>,
   sceneRef: React.RefObject<THREE.Scene>,
   cameraRef: React.RefObject<THREE.PerspectiveCamera>,
+  filename?: string,
 ) {
   if (!sceneRef.current || !cameraRef.current || !canvasRef.current) return;
 
@@ -50,7 +51,7 @@ export function downloadScreenshot(
       if (blob) {
         const link = document.createElement("a");
         link.href = URL.createObjectURL(blob);
-        link.download = "screenshot.png";
+        link.download = filename || "screenshot.png";
         link.click();
         URL.revokeObjectURL(link.href);
       }

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -70,7 +70,6 @@ function ThreeDViewer() {
 
   const handleScreenshot = () => {
     if (ref.current) {
-      // Use the Screenshoter utility functionthis.sceneRef.current && this.sceneRef.current.getElementsByTagName('canvas')[0]
       downloadScreenshot(ref.current && ref.current.getElementsByTagName("canvas")[0], 0.95, { width: 3840, height: 2160 }, 1, () => true, "screenshot.png");
     }
   };

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -70,7 +70,7 @@ function ThreeDViewer() {
   return (
     <>
       <DatasetPicker datasets={dataSets} selectedDataset={selectedDataset} onDatasetChange={setSelectedDataset} />
-      <Canvas style={{ backgroundColor: SCENE_BACKGROUND }} frameloop={"demand"}>
+      <Canvas style={{ backgroundColor: SCENE_BACKGROUND }} frameloop={"demand"} gl={{ preserveDrawingBuffer: true }}>
         <color attach="background" args={["#F6F5F4"]} />
         <Suspense fallback={<Loader />}>
           <PerspectiveCamera

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -13,7 +13,7 @@ import {
   LIGHT_1_COLOR,
   LIGHT_2_COLOR,
   LIGHT_2_POSITION,
-  SCENE_BACKGROUND,
+  LIGHT_SCENE_BACKGROUND,
 } from "../../../settings/threeDSettings.ts";
 import DatasetPicker from "./DatasetPicker.tsx";
 import Gizmo from "./Gizmo.tsx";
@@ -43,6 +43,8 @@ function ThreeDViewer() {
   const sceneRef = useRef<THREE.Scene | null>(null);
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
   const glRef = useRef<THREE.WebGLRenderer | null>(null);
+
+  const [sceneColor, setSceneColor] = useState(LIGHT_SCENE_BACKGROUND);
 
   // @ts-expect-error 'setShowNeurons' is declared but its value is never read.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -85,8 +87,8 @@ function ThreeDViewer() {
   return (
     <>
       <DatasetPicker datasets={dataSets} selectedDataset={selectedDataset} onDatasetChange={setSelectedDataset} />
-      <Canvas style={{ backgroundColor: SCENE_BACKGROUND }} frameloop={"demand"} gl={{ preserveDrawingBuffer: false }} onCreated={onCreated}>
-        <color attach="background" args={["#F6F5F4"]} />
+      <Canvas style={{ backgroundColor: sceneColor }} frameloop={"demand"} gl={{ preserveDrawingBuffer: false }} onCreated={onCreated}>
+        <color attach="background" args={[sceneColor]} />
         <Suspense fallback={<Loader />}>
           <PerspectiveCamera
             makeDefault
@@ -113,6 +115,8 @@ function ThreeDViewer() {
         setIsWireframe={setIsWireframe}
         recorderRef={recorderRef}
         handleScreenshot={handleScreenshot}
+        sceneColor={sceneColor}
+        setSceneColor={setSceneColor}
       />
     </>
   );

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -17,10 +17,9 @@ import {
 import DatasetPicker from "./DatasetPicker.tsx";
 import Gizmo from "./Gizmo.tsx";
 import Loader from "./Loader.tsx";
-import { Recorder } from "./Recorder";
+import type { Recorder } from "./Recorder";
 import STLViewer from "./STLViewer.tsx";
 import SceneControls from "./SceneControls.tsx";
-import { downloadScreenshot } from "./Screenshoter.ts";
 
 export interface Instance {
   id: string;
@@ -68,31 +67,6 @@ function ThreeDViewer() {
     setInstances(newInstances);
   }, [selectedDataset, workspace.availableNeurons, workspace.visibilities]);
 
-  const handleScreenshot = () => {
-    if (cameraControlRef.current) {
-      downloadScreenshot(document.getElementsByTagName("canvas")[0], 0.95, { width: 3840, height: 2160 }, 1, () => true, "screenshot.png");
-    }
-  };
-
-  const startRecording = () => {
-    if (recorderRef.current === null) {
-      const canvas = document.getElementsByTagName("canvas")[0];
-      recorderRef.current = new Recorder(canvas, {
-        mediaRecorderOptions: { mimeType: "video/webm" },
-        blobOptions: { type: "video/webm" },
-      });
-      recorderRef.current.startRecording();
-    }
-  };
-
-  const stopRecording = async () => {
-    if (recorderRef.current) {
-      recorderRef.current.stopRecording({ type: "video/webm" });
-      recorderRef.current.download("CanvasRecording.webm", { type: "video/webm" });
-      recorderRef.current = null;
-    }
-  };
-
   return (
     <>
       <DatasetPicker datasets={dataSets} selectedDataset={selectedDataset} onDatasetChange={setSelectedDataset} />
@@ -117,14 +91,7 @@ function ThreeDViewer() {
           <STLViewer instances={instances} isWireframe={isWireframe} />
         </Suspense>
       </Canvas>
-      <SceneControls
-        cameraControlRef={cameraControlRef}
-        isWireframe={isWireframe}
-        setIsWireframe={setIsWireframe}
-        handleScreenshot={handleScreenshot}
-        startRecording={startRecording}
-        stopRecording={stopRecording}
-      />
+      <SceneControls cameraControlRef={cameraControlRef} isWireframe={isWireframe} setIsWireframe={setIsWireframe} recorderRef={recorderRef} />
     </>
   );
 }

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -72,7 +72,7 @@ function ThreeDViewer() {
   }, [selectedDataset, workspace.availableNeurons, workspace.visibilities]);
 
   const handleScreenshot = () => {
-    downloadScreenshot(canvasRef, sceneRef, cameraRef);
+    downloadScreenshot(canvasRef, sceneRef, cameraRef, workspace.name);
   };
 
   const onCreated = (state) => {

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -70,7 +70,7 @@ function ThreeDViewer() {
   return (
     <>
       <DatasetPicker datasets={dataSets} selectedDataset={selectedDataset} onDatasetChange={setSelectedDataset} />
-      <Canvas style={{ backgroundColor: SCENE_BACKGROUND }} gl={{ alpha: true, antialias: true, preserveDrawingBuffer: true }}>
+      <Canvas style={{ backgroundColor: SCENE_BACKGROUND }} frameloop={"demand"}>
         <color attach="background" args={["#F6F5F4"]} />
         <Suspense fallback={<Loader />}>
           <PerspectiveCamera

--- a/applications/visualizer/frontend/src/helpers/utils.ts
+++ b/applications/visualizer/frontend/src/helpers/utils.ts
@@ -9,3 +9,15 @@ export function areSetsEqual<T>(setA: Set<T>, setB: Set<T>): boolean {
   }
   return true;
 }
+
+export function formatDate(d) {
+  return `${d.getFullYear()}${d.getMonth() + 1}${d.getDate()}-${pad(d.getHours(), 2)}${pad(d.getMinutes(), 2)}${pad(d.getSeconds(), 2)}`;
+}
+
+function pad(num, size) {
+  let s = num + "";
+  while (s.length < size) {
+    s = "0" + s;
+  }
+  return s;
+}

--- a/applications/visualizer/frontend/src/settings/threeDSettings.ts
+++ b/applications/visualizer/frontend/src/settings/threeDSettings.ts
@@ -9,8 +9,8 @@ export const LIGHT_1_COLOR = 0x404040;
 export const LIGHT_2_COLOR = 0xccccff;
 export const LIGHT_2_POSITION = new Vector3(-1, 0.75, -0.5);
 
-export const LIGHT_SCENE_BACKGROUND = 0xf6f5f4;
-export const DARK_SCENE_BACKGROUND = 0x21201c;
+export const LIGHT_SCENE_BACKGROUND = "#f6f5f4";
+export const DARK_SCENE_BACKGROUND = "#21201c";
 
 export const OUTLINE_THICKNESS = 0.05;
 export const OUTLINE_COLOR = "hotpink";

--- a/applications/visualizer/frontend/src/settings/threeDSettings.ts
+++ b/applications/visualizer/frontend/src/settings/threeDSettings.ts
@@ -9,7 +9,8 @@ export const LIGHT_1_COLOR = 0x404040;
 export const LIGHT_2_COLOR = 0xccccff;
 export const LIGHT_2_POSITION = new Vector3(-1, 0.75, -0.5);
 
-export const SCENE_BACKGROUND = "0xd9d8d4";
+export const LIGHT_SCENE_BACKGROUND = 0xf6f5f4;
+export const DARK_SCENE_BACKGROUND = 0x21201c;
 
 export const OUTLINE_THICKNESS = 0.05;
 export const OUTLINE_COLOR = "hotpink";


### PR DESCRIPTION
**Issue:** The use of preserveDrawingBuffer: true in the WebGL renderer can negatively impact performance. This setting is typically used to retain canvas content for tasks like taking screenshots. However, when preserveDrawingBuffer is set to false (the default), WebGL clears the drawing buffer after each frame, allowing for efficient memory management and optimal performance. When set to true, the buffer contents are preserved between frames, leading to increased memory usage and reduced rendering efficiency, which can significantly affect overall performance.

**Solution:** By default, preserveDrawingBuffer is set to false to improve performance during normal rendering.
A temporary WebGL renderer with preserveDrawingBuffer: true is created only when taking a screenshot to ensure the content is retained without affecting the performance during regular use.


https://github.com/user-attachments/assets/c05b2644-361c-4eb1-84bf-9622ee679b21

