### PR TITLE
New OOP-like storage update

### DIFF
--- a/applications/visualizer/frontend/src/contexts/GlobalContext.tsx
+++ b/applications/visualizer/frontend/src/contexts/GlobalContext.tsx
@@ -72,10 +72,7 @@ export const GlobalContextProvider: React.FC<GlobalContextProviderProps> = ({ ch
   };
 
   const updateWorkspace = (workspace: Workspace) => {
-    setWorkspaces((prev) => ({
-      ...prev,
-      [workspace.id]: workspace,
-    }));
+    setWorkspaces({ ...workspaces, [workspace.id]: workspace });
   };
 
   const setAllWorkspaces = (workspaces: Record<string, Workspace>) => {

--- a/applications/visualizer/frontend/src/main.tsx
+++ b/applications/visualizer/frontend/src/main.tsx
@@ -1,10 +1,11 @@
-import { enableMapSet } from "immer";
+import { enableMapSet, setAutoFreeze } from "immer";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { GlobalContextProvider } from "./contexts/GlobalContext.tsx";
 
 enableMapSet();
+setAutoFreeze(false);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <GlobalContextProvider>

--- a/applications/visualizer/frontend/src/models/synchronizer.ts
+++ b/applications/visualizer/frontend/src/models/synchronizer.ts
@@ -1,3 +1,4 @@
+import { immerable } from "immer";
 import type { Neuron } from "../rest";
 import { ViewerSynchronizationPair, ViewerType } from "./models";
 
@@ -11,6 +12,8 @@ const syncViewerDefs: Record<ViewerSynchronizationPair, [ViewerType, ViewerType]
 };
 
 class Synchronizer {
+  [immerable] = true;
+
   active: boolean;
   viewers: [ViewerType, ViewerType];
   readonly pair: ViewerSynchronizationPair;
@@ -96,6 +99,8 @@ class Synchronizer {
 }
 
 export class SynchronizerOrchestrator {
+  [immerable] = true;
+
   contexts: Record<ViewerType, SynchronizerContext>;
   synchronizers: Array<Synchronizer>;
 

--- a/applications/visualizer/frontend/tsconfig.json
+++ b/applications/visualizer/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "experimentalDecorators": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/applications/visualizer/frontend/tsconfig.node.json
+++ b/applications/visualizer/frontend/tsconfig.node.json
@@ -6,7 +6,8 @@
     "target": "ES2020",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
-    "strict": true
+    "strict": true,
+    "experimentalDecorators": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
This PR introduces a new way of performing updates using immer on the `workspace` using a decorator on the methods of the `Workspace` that need to trigger an update. The decorator also enables the capacity to trigger to actions on the workspace without having to rely on the "builder-like" pattern.

Here is an example of how we had to write the code before:

```ts
showNeuron(neuronId: string): void {
    const updated = produce(this, (draft: Workspace) => {
      if (!(neuronId in draft.visibilities)) {
        draft.visibilities[neuronId] = getDefaultViewerData(Visibility.Visible);
      }
      // todo: add actions for other viewers
      draft.visibilities[neuronId][ViewerType.Graph].visibility = Visibility.Visible;
      draft.visibilities[neuronId][ViewerType.ThreeD].visibility = Visibility.Visible;
    });

    this.updateContext(updated);
  }
```

and how we can write it now:

```ts
@triggerUpdate
  showNeuron(neuronId: string): void {
    if (!(neuronId in this.visibilities)) {
      this.visibilities[neuronId] = getDefaultViewerData(Visibility.Visible);
    }
    // todo: add actions for other viewers
    this.visibilities[neuronId][ViewerType.Graph].visibility = Visibility.Visible;
    this.visibilities[neuronId][ViewerType.ThreeD].visibility = Visibility.Visible;
  }
```

And here is how we can use the code now:

```ts
currentWorkspace.activateNeuron(neuron);   // both actions, activateNeuron and showNeuron are bith triggering updates
currentWorkspace.showNeuron(neuron.name);
```