### PR TITLE
Bug/cele 97 Debug issue with tiles missing depending on the order the widgets are opened

### DIFF
--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -131,8 +131,8 @@ const EMStackViewer = () => {
   const currSegLayer = useRef<VectorLayer<Feature> | null>(null);
   const clickedFeature = useRef<Feature | null>(null);
 
-  let ringEM: SlidingRing<TileLayer<XYZ>>;
-  let ringSeg: SlidingRing<VectorLayer<Feature>>;
+  const ringEM = useRef<SlidingRing<TileLayer<XYZ>>>()
+  const ringSeg = useRef<SlidingRing<VectorLayer<Feature>>>();
 
   // const debugLayer = new TileLayer({
   // 	source: new TileDebug({
@@ -175,7 +175,7 @@ const EMStackViewer = () => {
     const minZoomAvailable = tilegrid.getMinZoom();
     map.getView().setZoom(minZoomAvailable);
 
-    ringEM = new SlidingRing({
+    ringEM.current = new SlidingRing({
       cacheSize: ringSize,
       startAt: startSlice,
       extent: [minSlice, maxSlice],
@@ -196,7 +196,7 @@ const EMStackViewer = () => {
       },
     });
 
-    ringSeg = new SlidingRing({
+    ringSeg.current = new SlidingRing({
       cacheSize: ringSize,
       startAt: startSlice,
       extent: [minSlice, maxSlice],
@@ -245,11 +245,11 @@ const EMStackViewer = () => {
       const scrollUp = e.deltaY < 0;
 
       if (scrollUp) {
-        ringEM.next();
-        ringSeg.next();
+        ringEM.current.next();
+        ringSeg.current.next();
       } else {
-        ringEM.prev();
-        ringSeg.prev();
+        ringEM.current.prev();
+        ringSeg.current.prev();
       }
     });
 
@@ -274,8 +274,8 @@ const EMStackViewer = () => {
 
   const onResetView = () => {
     // reset sliding window
-    ringEM.goto(startSlice);
-    ringSeg.goto(startSlice);
+    ringEM.current.goto(startSlice);
+    ringSeg.current.goto(startSlice);
 
     if (!mapRef.current) return;
     const view = mapRef.current.getView();

--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -32,6 +32,7 @@ import SceneControls from "./SceneControls.tsx";
 // const height = 22528 / 2;
 const width = 19968;
 const height = 11008;
+const startZoom = 0;
 
 // const extent = [0, -height, width, 0];
 const extent = [0, 0, width, height];
@@ -44,6 +45,7 @@ const projection = new Projection({
 });
 
 const tilegrid = new TileGrid({
+  minZoom: 1, // tiles for zoom 0 not available in the dataset
   extent: extent,
   tileSize: 512,
   resolutions: [0.5, 1, 2, 4, 8, 16, 32].reverse(),
@@ -131,7 +133,7 @@ const EMStackViewer = () => {
   const currSegLayer = useRef<VectorLayer<Feature> | null>(null);
   const clickedFeature = useRef<Feature | null>(null);
 
-  const ringEM = useRef<SlidingRing<TileLayer<XYZ>>>()
+  const ringEM = useRef<SlidingRing<TileLayer<XYZ>>>();
   const ringSeg = useRef<SlidingRing<VectorLayer<Feature>>>();
 
   // const debugLayer = new TileLayer({
@@ -170,10 +172,6 @@ const EMStackViewer = () => {
       controls: [scale],
       interactions: interactions,
     });
-
-    // set map zoom to the minimum zoom possible
-    const minZoomAvailable = tilegrid.getMinZoom();
-    map.getView().setZoom(minZoomAvailable);
 
     ringEM.current = new SlidingRing({
       cacheSize: ringSize,
@@ -253,6 +251,10 @@ const EMStackViewer = () => {
       }
     });
 
+    // set map zoom to the minimum zoom possible
+    // const minZoomAvailable = tilegrid.getMinZoom();
+    map.getView().setZoom(startZoom);
+
     mapRef.current = map;
 
     return () => map.setTarget(null);
@@ -283,7 +285,7 @@ const EMStackViewer = () => {
     const center = getCenter(extent);
     view.setCenter(center);
 
-    const minZoomAvailable = tilegrid.getMinZoom();
+    const minZoomAvailable = view.getMinZoom();
     view.setZoom(minZoomAvailable);
   };
 


### PR DESCRIPTION
## Description

- this has been noticed during the internal sprint meeting
- if the EM widget is opened after the 3d viewer it does not load the tiles (sometimes)
- there is also the flashing behaviour, it would be good to understand more why this is happeining

## Debug

Could not replicate the issues after the missing files were upload to the bucket, but found some issues on some edge cases:

1. Easy to replicate when the EM viewer is very very small (e.g 300x480):
- [x] Zoom level 0 is requested, which does not exist and returns 404 on `*_*_6.jpg` files
- [x] Open 3D view, followed by EM view. Make the EM view super small and try to reset the view. A error like the following is raise `Uncaught TypeError: Cannot read properties of undefined (reading 'goto')` on the `onResetView` method in `EMStackTilesViewer.tsx:277`

See screen recording at <https://metacell.atlassian.net/browse/CELE-97>.
