### PR TITLE
Feature/cele 106

### DIFF
--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/SceneControls.tsx
@@ -224,17 +224,29 @@ function SceneControls({ cameraControlRef, isWireframe, setIsWireframe, recorder
       </Tooltip>
       <Divider />
       <Tooltip title="Play 3D viewer" placement="right-start">
-        <IconButton onClick={handleRotationToggle}>
+        <IconButton
+          onClick={handleRotationToggle}
+          sx={{
+            backgroundColor: isRotating ? "#ECF4FD" : "inherit",
+            "& .MuiSvgIcon-root": {
+              color: isRotating ? "#1568D5 !important" : "inherit",
+            },
+          }}
+        >
           <PlayArrowOutlined />
         </IconButton>
       </Tooltip>
       <Tooltip title={isRecording ? "Stop recording" : "Record viewer"} placement="right-start">
-        <IconButton onClick={handleRecordClick}>
-          <RadioButtonCheckedOutlined
-            sx={{
-              color: isRecording ? "red !important" : "inherit",
-            }}
-          />
+        <IconButton
+          onClick={handleRecordClick}
+          sx={{
+            backgroundColor: isRecording ? "#ECF4FD" : "inherit",
+            "& .MuiSvgIcon-root": {
+              color: isRecording ? "#1568D5 !important" : "inherit",
+            },
+          }}
+        >
+          <RadioButtonCheckedOutlined />
         </IconButton>
       </Tooltip>
       <Tooltip title="Download graph" placement="right-start">

--- a/applications/visualizer/frontend/src/contexts/GlobalContext.tsx
+++ b/applications/visualizer/frontend/src/contexts/GlobalContext.tsx
@@ -77,7 +77,7 @@ export const GlobalContextProvider: React.FC<GlobalContextProviderProps> = ({ ch
   };
 
   const updateWorkspace = (workspace: Workspace) => {
-    setWorkspaces({ ...workspaces, [workspace.id]: workspace });
+    setWorkspaces((prev) => ({ ...prev, [workspace.id]: workspace }));
   };
 
   const setAllWorkspaces = (workspaces: Record<string, Workspace>) => {


### PR DESCRIPTION
- In addition to updating the rotation icon style when rotation is enabled, this PR fixes an issue that occurred when toggling between workspaces or enabling the compare mode, as shown in the attached video, and also updates the recording icon style when recording is enabled to maintain UI consistency

https://github.com/user-attachments/assets/ba88206d-a8f4-439a-a188-f2bac3285846


https://github.com/user-attachments/assets/f52a5e33-283b-44bb-b25f-f8ec0719fe2e

- the updated style for the icons

https://github.com/user-attachments/assets/e9bc407d-5a2e-4ad9-a5cb-088b54b33b48

