### PR TITLE
CELE-109 Fixes screen flash with 3D viewer

### DIFF
--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/DatasetPicker.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/DatasetPicker.tsx
@@ -23,7 +23,7 @@ const DatasetPicker: React.FC<DatasetPickerProps> = ({ datasets, selectedDataset
       onChange={(newValue) => onDatasetChange(newValue)}
       getOptionLabel={(option: Dataset) => option.name}
       renderOption={(props, option) => (
-        <li {...props}>
+        <li {...props} key={`3Dviewer_dataset_${option.name}`}>
           <CheckIcon />
           <Typography>{option.name}</Typography>
         </li>

--- a/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/ThreeD/ThreeDViewer.tsx
@@ -4,7 +4,7 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import type * as THREE from "three";
 import { useSelectedWorkspace } from "../../../hooks/useSelectedWorkspace.ts";
 import { ViewerType, getNeuronUrlForDataset } from "../../../models/models.ts";
-import { type Dataset, OpenAPI } from "../../../rest";
+import type { Dataset } from "../../../rest";
 import {
   CAMERA_FAR,
   CAMERA_FOV,
@@ -61,12 +61,15 @@ function ThreeDViewer() {
       const viewerData = workspace.visibilities[neuronId]?.[ViewerType.ThreeD];
       const urls = getNeuronUrlForDataset(neuron, selectedDataset.id);
 
-      return urls.map((url, index) => ({
-        id: `${neuronId}-${index}`,
-        url: `${OpenAPI.BASE}/${url}`,
-        color: viewerData?.color || "#FFFFFF",
-        opacity: 1,
-      }));
+      return urls.map((url) => {
+        const neuronName = url.match(/([^/]+)(\.[^/]*)?$/)?.[1].replace(/(\.[^/]*)?$/, "");
+        return {
+          id: `${neuronName}`,
+          url,
+          color: viewerData?.color || "#FFFFFF",
+          opacity: 1,
+        };
+      });
     });
 
     setInstances(newInstances);

--- a/applications/visualizer/frontend/src/contexts/GlobalContext.tsx
+++ b/applications/visualizer/frontend/src/contexts/GlobalContext.tsx
@@ -6,7 +6,6 @@ import ErrorAlert from "../components/ErrorAlert.tsx";
 import ErrorBoundary from "../components/ErrorBoundary.tsx";
 import { ViewMode } from "../models";
 import { Workspace } from "../models";
-import { GlobalError } from "../models/Error.ts";
 import { type Dataset, DatasetsService } from "../rest";
 import type { SerializedGlobalContext } from "./SerializedContext.tsx";
 
@@ -103,10 +102,10 @@ export const GlobalContextProvider: React.FC<GlobalContextProviderProps> = ({ ch
   };
 
   const handleErrors = (error: Error) => {
-    if (error instanceof GlobalError) {
-      setErrorMessage(error.message);
-      setOpenErrorAlert(true);
-    }
+    // if (error instanceof GlobalError) {
+    setErrorMessage(error.message);
+    setOpenErrorAlert(true);
+    // }
   };
 
   const serializeGlobalContext = () => {


### PR DESCRIPTION
The problem of flash came from the fact that, depending on the dataset, the data couldn't be fetch. When that was the case, none of the scene was rendered, even if only one file couldn't be loaded. This commit changes the way the 3D images are loaded, and shows an error message to inform the user if one of the 3D images cannot be displayed (the other images for the requested neurons are displayed if they exists in the bucket).