### PR TITLE
CELE-121 Wormatlas external link backend implementation

### DIFF
--- a/applications/visualizer/api/openapi.json
+++ b/applications/visualizer/api/openapi.json
@@ -603,6 +603,10 @@
             "title": "Model3Durls",
             "type": "array"
           },
+          "reference": {
+            "title": "Reference",
+            "type": "string"
+          },
           "nclass": {
             "maxLength": 30,
             "title": "Nclass",
@@ -638,6 +642,7 @@
           "name",
           "datasetIds",
           "model3DUrls",
+          "reference",
           "nclass",
           "neurotransmitter",
           "type"

--- a/applications/visualizer/api/openapi.yaml
+++ b/applications/visualizer/api/openapi.yaml
@@ -191,6 +191,9 @@ components:
           maxLength: 10
           title: Neurotransmitter
           type: string
+        reference:
+          title: Reference
+          type: string
         type:
           maxLength: 10
           title: Type
@@ -199,6 +202,7 @@ components:
       - name
       - datasetIds
       - model3DUrls
+      - reference
       - nclass
       - neurotransmitter
       - type

--- a/applications/visualizer/backend/api/api.py
+++ b/applications/visualizer/backend/api/api.py
@@ -116,11 +116,12 @@ def annotate_neurons(neurons: BaseManager[NeuronModel]) -> None:
     for neuron, dataset in pre.union(post):
         neurons_dataset_ids[neuron].add(dataset)
 
-    # Add dataset ids and 3D representation path
+    # Add dataset ids, 3D representation path and documentation reference url
     for neuron in neurons:
         name = neuron.name
         neuron.dataset_ids = neurons_dataset_ids[name]  # type: ignore
         neuron.model3D_urls = [settings.NEURON_REPRESENTATION_3D_URL_FORMAT.format(name=name)]  # type: ignore
+        neuron.reference = settings.NEURON_REFERENCE_URL_FORMAT.format(nclass=neuron.nclass)  # type: ignore
 
 
 def neurons_from_datasets(

--- a/applications/visualizer/backend/api/schemas.py
+++ b/applications/visualizer/backend/api/schemas.py
@@ -54,6 +54,7 @@ class Neuron(ModelSchema, BilingualSchema):
     name: str
     dataset_ids: list[str]
     model3D_urls: list[str]
+    reference: str
 
     class Meta:
         model = NeuronModel

--- a/applications/visualizer/backend/openapi/openapi.json
+++ b/applications/visualizer/backend/openapi/openapi.json
@@ -603,6 +603,10 @@
             "title": "Model3Durls",
             "type": "array"
           },
+          "reference": {
+            "title": "Reference",
+            "type": "string"
+          },
           "nclass": {
             "maxLength": 30,
             "title": "Nclass",
@@ -638,6 +642,7 @@
           "name",
           "datasetIds",
           "model3DUrls",
+          "reference",
           "nclass",
           "neurotransmitter",
           "type"

--- a/applications/visualizer/backend/visualizer/settings/common.py
+++ b/applications/visualizer/backend/visualizer/settings/common.py
@@ -155,6 +155,9 @@ NINJA_PAGINATION_PER_PAGE = 100
 
 BASE_DATASET_URL = "resources/{dataset}"
 NEURON_REPRESENTATION_3D_URL_FORMAT = "resources/{{dataset}}/3d/{name}.stl"
+NEURON_REFERENCE_URL_FORMAT = (
+    "https://www.wormatlas.org/neurons/Individual%20Neurons/{nclass}frameset.html"
+)
 DATASET_NEURON_REPRESENTATION_3D_URL_FORMAT = "resources/{dataset}/3d/{{name}}.stl"
 # DATASET_EMDATA_URL_FORMAT = (
 #     f"resources/sem-adult/catmaid-tiles/{{index}}/{{x}}_{{y}}_{{z}}.jpg"

--- a/applications/visualizer/frontend/src/rest/models/Neuron.ts
+++ b/applications/visualizer/frontend/src/rest/models/Neuron.ts
@@ -6,6 +6,7 @@ export type Neuron = {
     name: string;
     datasetIds: Array<string>;
     model3DUrls: Array<string>;
+    reference: string;
     nclass: string;
     neurotransmitter: string;
     type: string;


### PR DESCRIPTION
Changes:

- New field `reference` was added to the `Neuron` schema
- When fetching neuron data, `reference` is annotated with the url to wormatlas 