### PR TITLE
CELE-123 Ingest synapses segmentation data

### DIFF
--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -140,10 +140,10 @@ To upload dataset files such as 3D neuron models, EM tile images and segmentatio
 When using the `add-dataset` subcommand, don't forget to specify the dataset ID corresponding to the files you're uploading (we will remember you otherwise).
 The following flags help determine which files to upload:
 
-- `-seg`/`--segmentation`: Path to the directory or files containing segmentation data.
+- `-seg`/`--segmentation`: Path to the directory or files containing neuron segmentation data.
 - `-3`/`--3d`: Path to the directory or files containing 3D neuron models.
 - `-e`/`--em`: Path to the directory or files containing EM tile images.
-- `-syn`/`--synapses`: Path to the directory or files containin the synapses data.
+- `-syn`/`--synapses`: Path to the directory or files containin synapses segmentation data.
 
 You can specify one, two, or all flags.
 

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -140,11 +140,12 @@ To upload dataset files such as 3D neuron models, EM tile images and segmentatio
 When using the `add-dataset` subcommand, don't forget to specify the dataset ID corresponding to the files you're uploading (we will remember you otherwise).
 The following flags help determine which files to upload:
 
-- `-s`/`--segmentation`: Path to the directory or files containing segmentation data.
+- `-seg`/`--segmentation`: Path to the directory or files containing segmentation data.
 - `-3`/`--3d`: Path to the directory or files containing 3D neuron models.
 - `-e`/`--em`: Path to the directory or files containing EM tile images.
+- `-syn`/`--synapses`: Path to the directory or files containin the synapses data.
 
-You can specify one, two, or all three flags.
+You can specify one, two, or all flags.
 
 For example, to upload 3D neuron models from `/path/to/3d/models` for the dataset `witvliet_2020_2`, use the following command:
 
@@ -168,14 +169,16 @@ To ingest segmentations in to C-Elegans you need to take an extra step:
 1. [Extract segmentations from the bitmap files](#extracting-segmentation-from-bitmap-files)
 2. [Ingest these segmentation into the C-Elegans cloud deployment](#ingesting-files)
 
+**This is valid for either neuron segmentations and synapses segmentations.**
+
 #### Extract segmentations from bitmap Files
 
-To extract the segmentation files from the bitmap files you will need a metadata file. This file contains information describing how the neurons can be identified in these bitmap file.
+To extract the segmentation files from the bitmap files you will need a metadata file. This file contains information describing how the neurons or synapses can be identified in these bitmap file.
 
-So assuming your bitmap images are located at `/path/to/bitmap/files` and your metadata file is at `/path/to/metadata/SEM_adult_metadata.txt`, run the following command to extract the segmentations data:
+So assuming your bitmap images are located at `/path/to/bitmap/files` and your metadata file is at `/path/to/metadata/the_metadata.txt`, run the following command to extract the segmentations data:
 
 ```bash
-celegans extract -i /path/to/bitmap/files -l /path/to/metadata/SEM_adult_metadata.txt
+celegans extract -i /path/to/bitmap/files -l /path/to/metadata/the_metadata.txt
 ```
 
 **The segmentation will be saved in the same directory as your bitmap files.**
@@ -189,10 +192,12 @@ This process may take a significant amount of time, depending on the number of f
 In same manner as described in [Ingest Files](#ingesting-files) section, you can upload the segmentation you just created by running:
 
 ```bash
-celegans ingest --data /path/to/data/db-raw-data add-dataset --id witvliet_2020_2 -s /path/to/bitmap/files
+celegans ingest --data /path/to/data/db-raw-data add-dataset --id witvliet_2020_2 -seg /path/to/bitmap/files
 ```
 
-Substituting the `--id` for your dataset ID and pointing to the segmentation output directory, which is the same as the bitmap files directory.
+1. Substituting the `--id` for your dataset ID
+2. Using the correct flag for either neuron segmentations (`-seg` or `--segmentation`) or the synapses segmentations (`-syn` or `--synapses`)
+3. Pointing to the segmentation output directory, which is the same as the bitmap files directory.
 
 ## FAQ
 
@@ -233,12 +238,19 @@ Our suggestion would be to manage and store your files as follows:
 │   │   │   ...
 │   │   ├── ...
 │   │   ...
-│   └── segmentations
-│       ├── s000.json
-│       ├── Dataset8_seg...127.vsseg_export_s000.png
-│       ├── s001.json
-│       ├── Dataset8_seg...127.vsseg_export_s001.png
-│       └── ...
+│   ├── segmentations
+│   │   ├── s000.json
+│   │   ├── Dataset8_seg...127.vsseg_export_s000.png
+│   │   ├── s001.json
+│   │   ├── Dataset8_seg...127.vsseg_export_s001.png
+│   │   └── ...
+│   └── synapses
+│       └── segmentations
+│           ├── s000.json
+│           ├── Dataset8_synapses__s000.png
+│           ├── s001.json
+│           ├── Dataset8_synapses__s001.png
+│           └── ...
 ├── dataset-2
 ├── dataset-3
 ...

--- a/ingestion/format-ingestion.md
+++ b/ingestion/format-ingestion.md
@@ -27,6 +27,11 @@ It is important to note that the dataset identifier is related to all data in th
 Segmentation files are json files that encode positions on neuron labels.
 They MUST follow the file path naming scheme: `**/*s<slice>.json`, where slice is a positive integer.
 
+## Synapses
+
+Synapses files are json files that encode positions on synapses labels.
+They MUST follow the file path naming scheme: `**/*s<slice>.json`, where slice is a positive integer.
+
 ## EM data
 
 Electromagnetic data MUST follow the file path namming scheme: `**/<slice>/<y>_<x>_<z>.jpg`, where `slice`, `x`, `y` and `z` are positive integers.
@@ -198,11 +203,17 @@ The cloud storage of the ingested files will be organized in the following patte
 │   │   │   ...
 │   │   ├── ...
 │   │   ...
-│   └── segmentations
-│       ├── metadata.json
-│       ├── s000.json
-│       ├── s001.json
-│       └── ...
+│   ├── segmentations
+│   │   ├── metadata.json
+│   │   ├── s000.json
+│   │   ├── s001.json
+│   │   └── ...
+│   └── synapses
+│       └── segmentations
+│           ├── metadata.json
+│           ├── s000.json
+│           ├── s001.json
+│           └── ...
 ├── dataset-2
 ├── dataset-3
 ...

--- a/ingestion/ingestion/ingest.py
+++ b/ingestion/ingestion/ingest.py
@@ -130,7 +130,7 @@ def add_add_dataset_flags(parser: ArgumentParser):
         parser: ArgumentParser, kind: str, *, short_flag: str | None = None
     ):
         parser.add_argument(
-            "-" + (short_flag or f"{kind.lower()[0]}"),
+            f"-{short_flag or kind.lower()[0]}",
             f"--{kind.lower()}",
             nargs="+",
             type=Path,

--- a/ingestion/ingestion/ingest.py
+++ b/ingestion/ingestion/ingest.py
@@ -26,14 +26,18 @@ from ingestion.storage.blob import (
     fs_3d_blob_name,
     fs_data_blob_name,
     fs_em_tile_blob_name,
-    fs_resolutions_metadata_blob_name,
     fs_segmentation_blob_name,
+    fs_segmentations_resolutions_metadata_blob_name,
+    fs_synapses_blob_name,
+    fs_synapses_resolutions_metadata_blob_name,
 )
 from ingestion.storage.filesystem import (
     find_3d_files,
     find_data_files,
     find_segmentation_files,
     find_segmentation_resolution_metadata_file,
+    find_synapses_files,
+    find_synapses_resolution_metadata_file,
     load_data,
     load_tiles,
 )
@@ -122,9 +126,11 @@ def add_add_dataset_flags(parser: ArgumentParser):
     #         help=f"{kind} directory",
     #     )
 
-    def add_in_paths(parser: ArgumentParser, kind: str):
+    def add_in_paths(
+        parser: ArgumentParser, kind: str, *, short_flag: str | None = None
+    ):
         parser.add_argument(
-            f"-{kind.lower()[0]}",
+            "-" + (short_flag or f"{kind.lower()[0]}"),
             f"--{kind.lower()}",
             nargs="+",
             type=Path,
@@ -132,9 +138,10 @@ def add_add_dataset_flags(parser: ArgumentParser):
         )
 
     # add_in_dir(parser, "connectivity")
-    add_in_paths(parser, "segmentation")
+    add_in_paths(parser, "segmentation", short_flag="seg")
     add_in_paths(parser, "3D")
     add_in_paths(parser, "EM")
+    add_in_paths(parser, "synapses", short_flag="syn")
 
 
 def validate_and_upload_data(
@@ -253,7 +260,45 @@ def upload_segmentations(
 
     rs.upload(
         resolutions_metadata,
-        fs_resolutions_metadata_blob_name(dataset_id),
+        fs_segmentations_resolutions_metadata_blob_name(dataset_id),
+        overwrite=overwrite,
+    )
+
+
+def upload_synapses(
+    dataset_id: str,
+    synapses_paths: list[Path],
+    rs: RemoteStorage,
+    *,
+    overwrite: bool = False,
+):
+    logger.info(f"uploading synapses...")
+
+    synapses_files = find_synapses_files(synapses_paths)
+
+    syn_files = list(synapses_files)
+    if len(syn_files) == 0:
+        logger.warning("skipping synapses upload: no files found")
+        return
+
+    pbar = tqdm(syn_files, disable=rs.dry_run)
+    for _, synapses_file in pbar:
+        pbar.set_description(str(synapses_file))
+        rs.upload(
+            synapses_file,
+            fs_synapses_blob_name(dataset_id, synapses_file),
+            overwrite=overwrite,
+        )
+
+    # upload synapses images resolution metadata
+    resolutions_metadata = find_synapses_resolution_metadata_file(synapses_paths)
+    if resolutions_metadata is None:
+        logger.warning("skipping synapses resolutions metadata upload: no files found")
+        return
+
+    rs.upload(
+        resolutions_metadata,
+        fs_synapses_resolutions_metadata_blob_name(dataset_id),
         overwrite=overwrite,
     )
 
@@ -449,6 +494,11 @@ def ingest_cmd(args: Namespace):
         upload_segmentations(dataset_id, args.segmentation, rs, overwrite=overwrite)
     elif dry_run:
         logger.warning("skipping segmentation upload: flag not set")
+
+    if args.synapses:
+        upload_synapses(dataset_id, args.synapses, rs, overwrite=overwrite)
+    elif dry_run:
+        logger.warning("skipping synapses upload: flag not set")
 
     if paths := getattr(args, "3d"):
         upload_3d(dataset_id, paths, rs, overwrite=overwrite)

--- a/ingestion/ingestion/storage/blob.py
+++ b/ingestion/ingestion/storage/blob.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from itertools import combinations
-import re
 from pathlib import Path
 
 from ingestion.em_metadata import Tile
-from ingestion.storage.filesystem import SEGMENTATION_REGEX
+from ingestion.storage.filesystem import SEGMENTATION_REGEX, SYNAPSES_REGEX
 
 STL_FILE_REGEX = r"-[^-_]+_[^-]+\.stl"
 
@@ -23,8 +23,20 @@ def fs_segmentation_blob_name(dataset_id: str, p: Path) -> str:
     return f"{dataset_id}/segmentations/s{match.group(1)}.json"
 
 
-def fs_resolutions_metadata_blob_name(dataset_id: str) -> str:
+def fs_synapses_blob_name(dataset_id: str, p: Path) -> str:
+    match = re.search(SYNAPSES_REGEX, p.name)
+    if not match:
+        raise Exception(f"could not extract the slice id from synapses file: {p}")
+
+    return f"{dataset_id}/synapses/segmentations/s{match.group(1)}.json"
+
+
+def fs_segmentations_resolutions_metadata_blob_name(dataset_id: str) -> str:
     return f"{dataset_id}/segmentations/metadata.json"
+
+
+def fs_synapses_resolutions_metadata_blob_name(dataset_id: str) -> str:
+    return f"{dataset_id}/synapses/segmentations/metadata.json"
 
 
 def find_longest_suffix(paths: list[Path]) -> str:

--- a/ingestion/ingestion/storage/filesystem.py
+++ b/ingestion/ingestion/storage/filesystem.py
@@ -85,7 +85,7 @@ def load_data(files: DataContainer[Path]) -> dict:
 
 Slice: TypeAlias = int
 
-SEGMENTATION_REGEX = r".*s(\d+)\.json$"
+SEGMENTATION_REGEX = re.compile(r".*s(\d+)\.json$")
 
 
 def find_segmentation_files(paths: list[Path]) -> Generator[tuple[Slice, Path]]:
@@ -111,6 +111,32 @@ def find_segmentation_files(paths: list[Path]) -> Generator[tuple[Slice, Path]]:
     )
 
 
+SYNAPSES_REGEX = re.compile(r".*s(\d+)\.json$")
+
+
+def find_synapses_files(paths: list[Path]) -> Generator[tuple[Slice, Path]]:
+    def extract_slice(filepath: Path) -> int:
+        match = re.search(SYNAPSES_REGEX, str(filepath))
+        if match:
+            return int(match.group(1))
+        raise Exception(
+            f"unable to extract slice number from synapses file: {filepath}"
+        )
+
+    if len(paths) == 1 and paths[0].is_dir():
+        return (
+            (extract_slice(f), f)
+            for f in paths[0].rglob("*.json")
+            if re.search(SYNAPSES_REGEX, str(f))
+        )
+
+    return (
+        (extract_slice(path), path)
+        for path in paths
+        if re.search(SYNAPSES_REGEX, str(path))
+    )
+
+
 def find_segmentation_resolution_metadata_file(paths: list[Path]) -> Path | None:
     if len(paths) == 0:
         return None
@@ -125,6 +151,10 @@ def find_segmentation_resolution_metadata_file(paths: list[Path]) -> Path | None
     if not metadata_path.exists():
         return None
     return metadata_path
+
+
+def find_synapses_resolution_metadata_file(paths: list[Path]) -> Path | None:
+    return find_segmentation_resolution_metadata_file(paths)  # same namming scheme
 
 
 DEFAULT_EXCLUDED_WORDS = ["synapse"]


### PR DESCRIPTION
Changes: 

1. Short flag the segmentations changed from `-s` to `-seg` so we can also use `-syn` for synapses (not super happy, suggestions are welcome)
2. Synapses are uploaded to `/<dataset_id>/synapses/segmentations/s<slice_number>.json`
3. Documentation was changed to match these changes
