### PR TITLE
CELE-126 Allows the EM viewer to not have any segmentation information

### DIFF
--- a/applications/visualizer/api/openapi.json
+++ b/applications/visualizer/api/openapi.json
@@ -520,6 +520,20 @@
             "title": "Slicerange",
             "type": "array"
           },
+          "maxResolution": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Maxresolution",
+            "type": "array"
+          },
           "resourceUrl": {
             "title": "Resourceurl",
             "type": "string"
@@ -574,6 +588,7 @@
           "nbSlices",
           "tileSize",
           "sliceRange",
+          "maxResolution",
           "resourceUrl",
           "segmentationUrl",
           "segmentationSize",

--- a/applications/visualizer/api/openapi.yaml
+++ b/applications/visualizer/api/openapi.yaml
@@ -84,6 +84,14 @@ components:
       type: object
     EMData:
       properties:
+        maxResolution:
+          maxItems: 2
+          minItems: 2
+          prefixItems:
+          - type: integer
+          - type: integer
+          title: Maxresolution
+          type: array
         maxZoom:
           title: Maxzoom
           type: integer
@@ -138,6 +146,7 @@ components:
       - nbSlices
       - tileSize
       - sliceRange
+      - maxResolution
       - resourceUrl
       - segmentationUrl
       - segmentationSize

--- a/applications/visualizer/backend/api/schemas.py
+++ b/applications/visualizer/backend/api/schemas.py
@@ -27,7 +27,7 @@ class EMData(BilingualSchema):
     nb_slices: int
     tile_size: tuple[int, int]
     slice_range: tuple[int, int]
-    max_resolution: tuple[int, int]  # EM tiles maximum resolution
+    max_resolution: tuple[int, int] | None  # EM tiles maximum resolution
     resource_url: str
     segmentation_url: str | None
     segmentation_size: tuple[int, int] | None

--- a/applications/visualizer/backend/api/schemas.py
+++ b/applications/visualizer/backend/api/schemas.py
@@ -27,6 +27,7 @@ class EMData(BilingualSchema):
     nb_slices: int
     tile_size: tuple[int, int]
     slice_range: tuple[int, int]
+    max_resolution: tuple[int, int]  # EM tiles maximum resolution
     resource_url: str
     segmentation_url: str | None
     segmentation_size: tuple[int, int] | None

--- a/applications/visualizer/backend/api/utils.py
+++ b/applications/visualizer/backend/api/utils.py
@@ -3,6 +3,10 @@ from django.conf import settings
 from .schemas import EMData
 from .models import Dataset
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 ## Some util functions
 async def to_list(q):
@@ -15,26 +19,33 @@ async def get_dataset_viewer_config(dataset: Dataset):
         return None
     em_metadata = config.em_config
     segmentation_metadata = config.segmentation_config
-    resolution = segmentation_metadata.get("resolution")
+    segmentation_resolution = segmentation_metadata.get("resolution")
+    tiled_img_resolution = em_metadata.get("resolution")
+    if not tiled_img_resolution and not segmentation_resolution:
+        logger.warning(
+            f"There is no img resolution computed from the tiles for the dataset '{dataset.id}', there is probably missing information in your metadata file"
+        )
     return EMData(
         min_zoom=em_metadata.get("minzoom"),
         max_zoom=em_metadata.get("maxzoom"),
         nb_slices=em_metadata.get("number_slices"),
         tile_size=tuple(em_metadata.get("tile_size")),
         slice_range=tuple(em_metadata.get("slice_range")),
-        max_resolution=tuple(em_metadata.get("resolution")),
-        segmentation_size=tuple(resolution) if resolution else None,
+        max_resolution=tuple(tiled_img_resolution) if tiled_img_resolution else None,
+        segmentation_size=(
+            tuple(segmentation_resolution) if segmentation_resolution else None
+        ),
         resource_url=settings.DATASET_EMDATA_URL_FORMAT.format(dataset=dataset.id),
         segmentation_url=(
             settings.DATASET_EMDATA_SEGMENTATION_URL_FORMAT.format(dataset=dataset.id)
-            if resolution
+            if segmentation_resolution
             else None
         ),
         synapses_segmentation_url=(
             settings.DATASET_EMDATA_SYNAPSES_SEGMENTATION_URL_FORMAT.format(
                 dataset=dataset.id
             )
-            if resolution
+            if segmentation_resolution
             else None
         ),
     )

--- a/applications/visualizer/backend/api/utils.py
+++ b/applications/visualizer/backend/api/utils.py
@@ -22,6 +22,7 @@ async def get_dataset_viewer_config(dataset: Dataset):
         nb_slices=em_metadata.get("number_slices"),
         tile_size=tuple(em_metadata.get("tile_size")),
         slice_range=tuple(em_metadata.get("slice_range")),
+        max_resolution=tuple(em_metadata.get("resolution")),
         segmentation_size=tuple(resolution) if resolution else None,
         resource_url=settings.DATASET_EMDATA_URL_FORMAT.format(dataset=dataset.id),
         segmentation_url=(

--- a/applications/visualizer/backend/openapi/openapi.json
+++ b/applications/visualizer/backend/openapi/openapi.json
@@ -520,6 +520,20 @@
             "title": "Slicerange",
             "type": "array"
           },
+          "maxResolution": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "title": "Maxresolution",
+            "type": "array"
+          },
           "resourceUrl": {
             "title": "Resourceurl",
             "type": "string"
@@ -574,6 +588,7 @@
           "nbSlices",
           "tileSize",
           "sliceRange",
+          "maxResolution",
           "resourceUrl",
           "segmentationUrl",
           "segmentationSize",

--- a/applications/visualizer/backend/visualizer/settings/production.py
+++ b/applications/visualizer/backend/visualizer/settings/production.py
@@ -135,7 +135,13 @@ class DbDataDownloader:
 
     @classmethod
     def get_segmentation_metadata(cls, dataset_id):
-        file = BASE_DIR / DB_RAW_DATA_FOLDER / dataset_id / "segmentations" / "metadata.json"
+        file = (
+            BASE_DIR
+            / DB_RAW_DATA_FOLDER
+            / dataset_id
+            / "segmentations"
+            / "metadata.json"
+        )
         if not file.exists():
             return {}
         return json.loads(file.read_text())

--- a/applications/visualizer/backend/visualizer/settings/production.py
+++ b/applications/visualizer/backend/visualizer/settings/production.py
@@ -135,14 +135,14 @@ class DbDataDownloader:
 
     @classmethod
     def get_segmentation_metadata(cls, dataset_id):
-        file = BASE_DIR / DB_RAW_DATA_FOLDER / dataset_id / "segmentation_metadata.json"
+        file = BASE_DIR / DB_RAW_DATA_FOLDER / dataset_id / "segmentations" / "metadata.json"
         if not file.exists():
             return {}
         return json.loads(file.read_text())
 
     @classmethod
     def get_em_metadata(cls, dataset_id):
-        file = BASE_DIR / DB_RAW_DATA_FOLDER / dataset_id / "em_metadata.json"
+        file = BASE_DIR / DB_RAW_DATA_FOLDER / dataset_id / "em" / "metadata.json"
         if not file.exists():
             return {}
         return json.loads(file.read_text())

--- a/applications/visualizer/backend/visualizer/views.py
+++ b/applications/visualizer/backend/visualizer/views.py
@@ -35,7 +35,7 @@ TILE_SIZE = 512  # Should be computed
 BLACK_TILE = Image.new("RGB", (TILE_SIZE, TILE_SIZE))
 BLACK_TILE_BUFFER = io.BytesIO()
 BLACK_TILE.save(BLACK_TILE_BUFFER, format="JPEG")
-MAX_ZOOM = 6  # Should be set
+MAX_ZOOM = 5  # Should be set
 
 
 def get_tile(request, dataset, slice, x, y, zoom):

--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -278,10 +278,11 @@ const EMStackViewer = () => {
     const hasSynapseSegmentations = !!firstActiveDataset.emData.synapsesSegmentationUrl;
 
     const tilegrid = new TileGrid({
-      minZoom: firstActiveDataset.emData.minZoom + 1,
+      minZoom: firstActiveDataset.emData.minZoom,
       extent: extent,
       tileSize: firstActiveDataset.emData.tileSize[0],
-      resolutions: [0.5, 1, 2, 4, 8, 16, 32].reverse(),
+      // resolutions: [0.5, 1, 2, 4, 8, 16, 32].reverse(),
+      resolutions: [0.25, 0.5, 1, 2, 4, 8, 16].reverse(),
     });
 
     // const debugLayer = new TileLayer({
@@ -295,9 +296,9 @@ const EMStackViewer = () => {
       target: "emviewer",
       layers: [],
       view: new View({
-        zoom: firstActiveDataset.emData.minZoom + 1,
-        minZoom: firstActiveDataset.emData.minZoom + 1,
-        maxZoom: firstActiveDataset.emData.maxZoom + 1,
+        zoom: firstActiveDataset.emData.minZoom,
+        minZoom: firstActiveDataset.emData.minZoom,
+        maxZoom: firstActiveDataset.emData.maxZoom,
         projection: projection,
         center: getCenter(extent),
         extent: extent,

--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -278,7 +278,7 @@ const EMStackViewer = () => {
     const hasSynapseSegmentations = !!firstActiveDataset.emData.synapsesSegmentationUrl;
 
     const tilegrid = new TileGrid({
-      minZoom: firstActiveDataset.emData.minZoom, // tiles for zoom 0 not available in the dataset
+      minZoom: firstActiveDataset.emData.minZoom + 1,
       extent: extent,
       tileSize: firstActiveDataset.emData.tileSize[0],
       resolutions: [0.5, 1, 2, 4, 8, 16, 32].reverse(),
@@ -295,10 +295,14 @@ const EMStackViewer = () => {
       target: "emviewer",
       layers: [],
       view: new View({
+        zoom: firstActiveDataset.emData.minZoom + 1,
+        minZoom: firstActiveDataset.emData.minZoom + 1,
+        maxZoom: firstActiveDataset.emData.maxZoom + 1,
         projection: projection,
         center: getCenter(extent),
         extent: extent,
         resolutions: tilegrid.getResolutions(), // forces view zoom options
+        constrainOnlyCenter: true,
       }),
       controls: [scale],
       interactions: interactions,

--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import "ol/ol.css";
 import { type Feature, Map as OLMap, View } from "ol";
 import type { FeatureLike } from "ol/Feature";
@@ -174,11 +174,39 @@ const interactions = defaultInteractions({
   }),
 ]);
 
+const NoEMData = () => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100%",
+      }}
+    >
+      <Typography variant="h6" color="text.secondary">
+        No EM Data Available
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+        Please select a dataset containing EM data to view
+      </Typography>
+    </Box>
+  );
+};
+
 const EMStackViewer = () => {
   const currentWorkspace = useGlobalContext().getCurrentWorkspace();
 
   // We take the first active dataset at the moment (will change later)
   const firstActiveDataset = Object.values(currentWorkspace.activeDatasets)?.[0];
+  if (!firstActiveDataset.emData) {
+    return <NoEMData />;
+  }
+
+  const hasNeuronSegmentations = !!firstActiveDataset.emData.segmentationSize;
+  const hasSynapseSegmentations = !!firstActiveDataset.emData.synapsesSegmentationUrl;
+
   const [minSlice, maxSlice] = firstActiveDataset.emData.sliceRange;
   const startSlice = Math.floor((maxSlice + minSlice) / 2);
   const [segSlice, segSetSlice] = useState<number>(startSlice);
@@ -195,15 +223,16 @@ const EMStackViewer = () => {
   const [showNeurons, setShowNeurons] = useState<boolean>(true);
   const [showSynapses, setShowSynapses] = useState<boolean>(true);
 
-  const startZoom = useMemo(() => {
-    const emData = firstActiveDataset.emData;
-    if (!emData) {
-      return undefined;
-    }
-    return emData.minZoom;
-  }, [firstActiveDataset.emData]);
+  // EM tiles reverse the maximum and minimum zooms
+  // lower numbers are more zoomed in (0 is max zoom possible)
+  // In OpenLayers, 0 is the minimum zoom and higher number are
+  // more zoomed in.
+  const startZoom = firstActiveDataset.emData.maxZoom;
 
-  const extent = useMemo(() => [0, 0, ...firstActiveDataset.emData.segmentationSize], [firstActiveDataset.emData.segmentationSize]);
+  const extent = useMemo(
+    () => [0, 0, ...(firstActiveDataset.emData.segmentationSize || firstActiveDataset.emData.maxResolution)],
+    [firstActiveDataset.emData.segmentationSize],
+  );
 
   const projection = useMemo(() => {
     return new Projection({
@@ -309,46 +338,48 @@ const EMStackViewer = () => {
       newLayer: (slice) => newEMLayer(firstActiveDataset, slice, tilegrid, projection),
     });
 
-    ringSeg.current = new SlidingLayer({
-      map: map,
-      cacheSize: ringSize,
-      startAt: startSlice,
-      extent: [minSlice, maxSlice],
-      newLayer: (slice) => newSegLayer(firstActiveDataset, slice),
-      onSlide: (slice, layer) => {
-        layer.setStyle((feature) => neuronsStyleRef.current(feature));
-        currSegLayer.current = layer;
-        segSetSlice(slice);
-      },
-    });
+    if (hasNeuronSegmentations) {
+      ringSeg.current = new SlidingLayer({
+        map: map,
+        cacheSize: ringSize,
+        startAt: startSlice,
+        extent: [minSlice, maxSlice],
+        newLayer: (slice) => newSegLayer(firstActiveDataset, slice),
+        onSlide: (slice, layer) => {
+          layer.setStyle((feature) => neuronsStyleRef.current(feature));
+          currSegLayer.current = layer;
+          segSetSlice(slice);
+        },
+      });
 
-    map.on("click", (e) => onFeatureClickRef.current(e.coordinate));
+      map.on("click", (e) => onFeatureClickRef.current(e.coordinate));
+    }
 
-    ringSynSeg.current = new SlidingLayer({
-      map: map,
-      cacheSize: ringSize,
-      startAt: startSlice,
-      extent: [minSlice, maxSlice],
-      newLayer: (slice) => newSynapsesSegLayer(firstActiveDataset, slice),
-      onSlide: (_, layer) => {
-        layer.setStyle((feature) => synapsesStyleRef.current(feature));
-        currSynSegLayer.current = layer;
-      },
-    });
-
-    newSynapsesSegLayer;
+    if (hasSynapseSegmentations) {
+      ringSynSeg.current = new SlidingLayer({
+        map: map,
+        cacheSize: ringSize,
+        startAt: startSlice,
+        extent: [minSlice, maxSlice],
+        newLayer: (slice) => newSynapsesSegLayer(firstActiveDataset, slice),
+        onSlide: (_, layer) => {
+          layer.setStyle((feature) => synapsesStyleRef.current(feature));
+          currSynSegLayer.current = layer;
+        },
+      });
+    }
 
     function handleSliceScroll(e: WheelEvent) {
       const scrollUp = e.deltaY < 0;
 
       if (scrollUp) {
         ringEM.current.next();
-        ringSeg.current.next();
-        ringSynSeg.current.next();
+        ringSeg.current?.next();
+        ringSynSeg.current?.next();
       } else {
         ringEM.current.prev();
-        ringSeg.current.prev();
-        ringSynSeg.current.prev();
+        ringSeg.current?.prev();
+        ringSynSeg.current?.prev();
       }
     }
 
@@ -400,8 +431,8 @@ const EMStackViewer = () => {
   const onResetView = () => {
     // reset sliding window
     ringEM.current.goto(startSlice);
-    ringSeg.current.goto(startSlice);
-    ringSynSeg.current.goto(startSlice);
+    ringSeg.current?.goto(startSlice);
+    ringSynSeg.current?.goto(startSlice);
 
     if (!mapRef.current) return;
     const view = mapRef.current.getView();

--- a/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
+++ b/applications/visualizer/frontend/src/components/viewers/EM/EMStackTilesViewer.tsx
@@ -13,16 +13,16 @@ import VectorLayer from "ol/layer/Vector";
 import { Projection } from "ol/proj";
 import { XYZ } from "ol/source";
 import VectorSource from "ol/source/Vector";
+import type Style from "ol/style/Style";
 import { TileGrid } from "ol/tilegrid";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useGlobalContext } from "../../../contexts/GlobalContext.tsx";
-import { ViewerType, getEMDataURL, getSegmentationURL, getSynapsesSegmentationURL } from "../../../models/models.ts";
+import { ViewerType, getEMDataURL, getEMResolution, getSegmentationURL, getSynapsesSegmentationURL } from "../../../models/models.ts";
 import type { Workspace } from "../../../models/workspace.ts";
 import type { Dataset } from "../../../rest/index.ts";
 import SceneControls from "./SceneControls.tsx";
-import { activeNeuronStyle, cellFeatureName, selectedNeuronStyle, selectedSynapseStyle, activeSynapseStyle } from "./neuronsMapFeature.ts";
+import { activeNeuronStyle, activeSynapseStyle, cellFeatureName, selectedNeuronStyle, selectedSynapseStyle } from "./neuronsMapFeature.ts";
 import { SlidingLayer } from "./slidingLayer.ts";
-import Style from "ol/style/Style";
 
 const newEMLayer = (dataset: Dataset, slice: number, tilegrid: TileGrid, projection: Projection): TileLayer<XYZ> => {
   return new TileLayer({
@@ -204,9 +204,6 @@ const EMStackViewer = () => {
     return <NoEMData />;
   }
 
-  const hasNeuronSegmentations = !!firstActiveDataset.emData.segmentationSize;
-  const hasSynapseSegmentations = !!firstActiveDataset.emData.synapsesSegmentationUrl;
-
   const [minSlice, maxSlice] = firstActiveDataset.emData.sliceRange;
   const startSlice = Math.floor((maxSlice + minSlice) / 2);
   const [segSlice, segSetSlice] = useState<number>(startSlice);
@@ -223,16 +220,7 @@ const EMStackViewer = () => {
   const [showNeurons, setShowNeurons] = useState<boolean>(true);
   const [showSynapses, setShowSynapses] = useState<boolean>(true);
 
-  // EM tiles reverse the maximum and minimum zooms
-  // lower numbers are more zoomed in (0 is max zoom possible)
-  // In OpenLayers, 0 is the minimum zoom and higher number are
-  // more zoomed in.
-  const startZoom = firstActiveDataset.emData.maxZoom;
-
-  const extent = useMemo(
-    () => [0, 0, ...(firstActiveDataset.emData.segmentationSize || firstActiveDataset.emData.maxResolution)],
-    [firstActiveDataset.emData.segmentationSize],
-  );
+  const extent = useMemo(() => [0, 0, ...getEMResolution(firstActiveDataset)], [firstActiveDataset]);
 
   const projection = useMemo(() => {
     return new Projection({
@@ -242,22 +230,6 @@ const EMStackViewer = () => {
       metersPerUnit: 2e-9, // 2 nm voxels
     });
   }, [extent]);
-
-  const tilegrid = useMemo(() => {
-    return new TileGrid({
-      minZoom: 1, // tiles for zoom 0 not available in the dataset
-      extent: extent,
-      tileSize: firstActiveDataset.emData.tileSize[0],
-      resolutions: [0.5, 1, 2, 4, 8, 16, 32].reverse(),
-    });
-  }, [extent, firstActiveDataset.emData.tileSize]);
-
-  // const debugLayer = new TileLayer({
-  // 	source: new TileDebug({
-  // 		projection: projection,
-  // 		tileGrid: tilegrid,
-  // 	}),
-  // });
 
   const makeFeatureClickHandler = () => (position) =>
     selectAcrossLayers(
@@ -298,24 +270,26 @@ const EMStackViewer = () => {
     currSynSegLayer.current.getSource().changed();
   }, [currentWorkspace.getSelection(ViewerType.EM), segSlice]);
 
-  useEffect(() => {
-    if (!ringSeg.current) {
-      return;
-    }
-    showNeurons ? ringSeg.current.enable() : ringSeg.current.disable();
-  }, [showNeurons]);
+  useEffect(() => ringSeg.current?.setVisibility(showNeurons), [showNeurons]);
+  useEffect(() => ringSynSeg.current?.setVisibility(showSynapses), [showSynapses]);
 
   useEffect(() => {
-    if (!ringSynSeg.current) {
-      return;
-    }
-    showSynapses ? ringSynSeg.current.enable() : ringSynSeg.current.disable();
-  }, [showSynapses]);
+    const hasNeuronSegmentations = !!firstActiveDataset.emData.segmentationSize;
+    const hasSynapseSegmentations = !!firstActiveDataset.emData.synapsesSegmentationUrl;
 
-  useEffect(() => {
-    if (mapRef.current) {
-      return;
-    }
+    const tilegrid = new TileGrid({
+      minZoom: firstActiveDataset.emData.minZoom, // tiles for zoom 0 not available in the dataset
+      extent: extent,
+      tileSize: firstActiveDataset.emData.tileSize[0],
+      resolutions: [0.5, 1, 2, 4, 8, 16, 32].reverse(),
+    });
+
+    // const debugLayer = new TileLayer({
+    // 	source: new TileDebug({
+    // 		projection: projection,
+    // 		tileGrid: tilegrid,
+    // 	}),
+    // });
 
     const map = new OLMap({
       target: "emviewer",
@@ -354,7 +328,6 @@ const EMStackViewer = () => {
 
       map.on("click", (e) => onFeatureClickRef.current(e.coordinate));
     }
-
     if (hasSynapseSegmentations) {
       ringSynSeg.current = new SlidingLayer({
         map: map,
@@ -406,13 +379,14 @@ const EMStackViewer = () => {
     });
 
     // set map zoom to the minimum zoom possible
-    // const minZoomAvailable = tilegrid.getMinZoom();
-    map.getView().setZoom(startZoom);
+    const minZoomAvailable = tilegrid.getMinZoom();
+    // const startZoom = firstActiveDataset.emData.minZoom;
+    map.getView().setZoom(minZoomAvailable);
 
     mapRef.current = map;
 
     return () => map.setTarget(null);
-  }, []);
+  }, [firstActiveDataset, extent, projection, startSlice, maxSlice, minSlice]);
 
   const onControlZoomIn = () => {
     if (!mapRef.current) return;

--- a/applications/visualizer/frontend/src/components/viewers/EM/slidingLayer.ts
+++ b/applications/visualizer/frontend/src/components/viewers/EM/slidingLayer.ts
@@ -1,7 +1,7 @@
-import { Map } from "ol";
-import Layer from "ol/layer/Layer";
+import type { Map } from "ol";
+import type Layer from "ol/layer/Layer";
 import { SlidingRing } from "../../../helpers/slidingRing";
-import { type SlidingRingOptions } from "../../../helpers/slidingRing";
+import type { SlidingRingOptions } from "../../../helpers/slidingRing";
 
 interface SlidingLayerOptions<T extends Layer> extends Pick<SlidingRingOptions<T>, "cacheSize" | "startAt" | "extent"> {
   map: Map;
@@ -11,8 +11,8 @@ interface SlidingLayerOptions<T extends Layer> extends Pick<SlidingRingOptions<T
 
 export class SlidingLayer<T extends Layer> {
   private swindow: SlidingRing<T>;
-  private opaque: boolean = true; // loaded but is transparent
-  private visible: boolean = true; // not loaded and can not be seen
+  private opaque = true; // loaded but is transparent
+  private visible = true; // not loaded and can not be seen
 
   constructor(options: SlidingLayerOptions<T>) {
     const { map, newLayer, onSlide, ...ringOpts } = options;
@@ -27,7 +27,7 @@ export class SlidingLayer<T extends Layer> {
         return layer;
       },
       onSelected: (slice, layer) => {
-        onSlide && onSlide(slice, layer);
+        onSlide?.(slice, layer);
         layer.setOpacity(Number(this.opaque));
       },
       onUnselected: (_, layer) => {
@@ -52,27 +52,23 @@ export class SlidingLayer<T extends Layer> {
   }
 
   disable() {
-    if (!this.visible) {
-      return;
-    }
-
-    this.swindow.ring.forEach(({ o }) => {
-      o.setVisible(false);
-    });
-
-    this.visible = false;
+    this.setVisibility(false);
   }
 
   enable() {
-    if (this.visible) {
+    this.setVisibility(true);
+  }
+
+  setVisibility(isVisible: boolean) {
+    if (this.visible === isVisible) {
       return;
     }
 
-    this.swindow.ring.forEach(({ o }) => {
-      o.setVisible(true);
-    });
+    for (const { o } of this.swindow.ring) {
+      o.setVisible(isVisible);
+    }
 
-    this.visible = true;
+    this.visible = isVisible;
   }
 
   next() {

--- a/applications/visualizer/frontend/src/models/models.ts
+++ b/applications/visualizer/frontend/src/models/models.ts
@@ -93,6 +93,10 @@ export function getSynapsesSegmentationURL(dataset: Dataset, sliceIndex: number)
   return buildUrlFromFormat(dataset.emData.synapsesSegmentationUrl, sliceIndex?.toString());
 }
 
+export function getEMResolution(dataset: Dataset) {
+  return dataset.emData?.segmentationSize || dataset.emData?.maxResolution;
+}
+
 export enum Alignment {
   Left = "left",
   Right = "right",

--- a/applications/visualizer/frontend/src/rest/models/EMData.ts
+++ b/applications/visualizer/frontend/src/rest/models/EMData.ts
@@ -8,6 +8,7 @@ export type EMData = {
     nbSlices: number;
     tileSize: any[];
     sliceRange: any[];
+    maxResolution: any[];
     resourceUrl: string;
     segmentationUrl: (string | null);
     segmentationSize: (any[] | null);

--- a/ingestion/ingestion/em_metadata.py
+++ b/ingestion/ingestion/em_metadata.py
@@ -112,7 +112,7 @@ class Pyramid:
     def extent(self) -> tuple[int, int, int, int]:
         maxX, maxY = (0, 0)
         if self.zooms:
-            maxX, maxY = self.levels[self.maxzoom].resolution
+            maxX, maxY = self.levels[self.minzoom].resolution
 
         # TODO: this may be optimized further to excluse black tiles from being requested
         minX, minY = (0, 0)
@@ -125,12 +125,12 @@ class Pyramid:
     @property
     def minzoom(self) -> int:
         """Minimum zoom value that exits in the pyramid"""
-        return max(self.zooms)
+        return min(self.zooms)
 
     @property
     def maxzoom(self) -> int:
         """Maximum zoom value that exits in the pyramid"""
-        return min(self.zooms)
+        return max(self.zooms)
 
     @property
     def tile_dimensions(self) -> tuple[int, int]:
@@ -147,7 +147,7 @@ class Pyramid:
         if len(zooms) == 0:
             return (0, 0)  # no data
 
-        tile_grid = self.levels[self.maxzoom]
+        tile_grid = self.levels[self.minzoom + 1]
         [w, h] = self.tile_dimensions
         [r, c] = tile_grid.size
 
@@ -387,8 +387,8 @@ if __name__ == "__main__":
                     continue
                 assert tile.zoom == lvl
 
-        assert pyramid.maxzoom == min(pyramid.levels.keys())
-        assert pyramid.minzoom == max(pyramid.levels.keys())
+        assert pyramid.maxzoom == max(pyramid.levels.keys())
+        assert pyramid.minzoom == min(pyramid.levels.keys())
 
     validate_pyramid(pyramid)
     print_dataclass(pyramid, exclude={"levels"})

--- a/ingestion/ingestion/em_metadata.py
+++ b/ingestion/ingestion/em_metadata.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from itertools import chain, groupby
 from pathlib import Path
+from typing import Iterator
 
 from PIL import Image
 from pydantic import BaseModel
@@ -31,6 +32,9 @@ class TileGrid:
     zoom: int
     size: tuple[int, int]  # rows and columns
     matrix: list[list[Tile | None]]  # tiles organized in a matrix [row][col]
+
+    def __iter__(self) -> Iterator[Tile | None]:
+        return (tile for row in self.matrix for tile in row)
 
     @staticmethod
     def _matrix_size(tiles: list[Tile]) -> tuple[int, int]:
@@ -97,7 +101,7 @@ class TileGrid:
 
 @dataclass
 class Pyramid:
-    """A piramid structure with a tile matrix for each zoom level"""
+    """A pyramid structure with a tile matrix for each zoom level"""
 
     levels: dict[int, TileGrid]
 
@@ -120,12 +124,12 @@ class Pyramid:
 
     @property
     def minzoom(self) -> int:
-        """Minimum zoom value that exits in the piramid"""
+        """Minimum zoom value that exits in the pyramid"""
         return max(self.zooms)
 
     @property
     def maxzoom(self) -> int:
-        """Maximum zoom value that exits in the piramid"""
+        """Maximum zoom value that exits in the pyramid"""
         return min(self.zooms)
 
     @property
@@ -160,7 +164,7 @@ class Pyramid:
         return cls(levels)
 
 
-class SliceMetadata(BaseModel):
+class SliceMetadata:
     slice: int
     zooms: list[int]
     minzoom: int
@@ -181,25 +185,25 @@ class EMMetadata(BaseModel):
     def from_tiles(cls, tiles: list[Tile]) -> EMMetadata:
         available_slices = []
 
-        piramid = None
+        pyramid = None
         tiles.sort(key=operator.attrgetter("slice"))  # groupby expects things sorted
-        previous_piramid = None
+        previous_pyramid = None
         for slice, stiles in groupby(tiles, lambda t: t.slice):
-            piramid = Pyramid.build(list(stiles))
+            pyramid = Pyramid.build(list(stiles))
             available_slices.append(slice)
             assert (
-                not previous_piramid
-                or previous_piramid.tile_dimensions == piramid.tile_dimensions
+                not previous_pyramid
+                or previous_pyramid.tile_dimensions == pyramid.tile_dimensions
             )
-        assert piramid
+        assert pyramid
         return cls(
             number_slices=len(available_slices),
             slice_range=(min(available_slices), max(available_slices)),
             slices=available_slices,
-            minzoom=piramid.minzoom,
-            maxzoom=piramid.maxzoom,
-            tile_size=piramid.tile_dimensions,
-            resolution=piramid.resolution,
+            minzoom=pyramid.minzoom,
+            maxzoom=pyramid.maxzoom,
+            tile_size=pyramid.tile_dimensions,
+            resolution=pyramid.resolution,
         )
 
     def merge(self, emm2: EMMetadata) -> EMMetadata:
@@ -227,9 +231,13 @@ class EMMetadata(BaseModel):
 
 
 if __name__ == "__main__":
-    import sys
+    import logging
     from argparse import ArgumentParser
+    from dataclasses import fields, is_dataclass
+    from inspect import getmembers, isdatadescriptor
+    from sys import maxsize
 
+    from ingestion.log import setup_logger
     from ingestion.storage.filesystem import load_tiles
 
     parser = ArgumentParser(description="computed EM tiles metadata")
@@ -240,13 +248,153 @@ if __name__ == "__main__":
         help=f"directory, files or glob match for EM data",
     )
     parser.add_argument(
-        "--indent",
-        type=int,
-        help="indentation to use in the JSON output.",
-        default=None,
+        "--debug",
+        help="runs with debug logs",
+        default=False,
+        action="store_true",
     )
 
     args = parser.parse_args()
-    tiles = load_tiles(args.em_paths)
-    metadata = EMMetadata.from_tiles(list(tiles))
-    print(metadata.model_dump_json(indent=args.indent), file=sys.stdout)
+
+    setup_logger(args.debug)
+    logger = logging.getLogger("em_data")
+
+    tiles = list(load_tiles(args.em_paths))
+    logger.debug(f"found {len(tiles)} tiles")
+
+    def print_dataclass(dc, *, exclude: set[str] | None = None):
+        if not is_dataclass(dc):
+            raise ValueError("Input must be a dataclass instance")
+
+        exclude = exclude or set()
+
+        attrs = []
+        attrs.extend(
+            (field.name, getattr(dc, field.name))
+            for field in fields(dc)
+            if field.name not in exclude
+        )
+        properties = getmembers(type(dc), isdatadescriptor)
+        attrs.extend(
+            (name, getattr(dc, name))
+            for name, _ in properties
+            if isinstance(getattr(type(dc), name), property) and name not in exclude
+        )
+
+        if not attrs:
+            return
+
+        max_length = max(len(name) for name, _ in attrs)
+        for name, val in attrs:
+            print(f"{name:<{max_length}}: {val}")
+
+    def print_basemodel(model: BaseModel, exclude: set[str] | None = None):
+        if not isinstance(model, BaseModel):
+            raise ValueError("Input must be a Pydantic BaseModel instance")
+
+        exclude = exclude or set()
+
+        fields = [
+            (field_name, getattr(model, field_name))
+            for field_name in model.model_fields.keys()
+            if field_name not in exclude
+        ]
+
+        if not fields:
+            return
+
+        max_length = max(len(name) for name, _ in fields)
+        for name, val in fields:
+            print(f"{name:<{max_length}}: {val}")
+
+    print("========= EM metadata =========")
+
+    em_meta = EMMetadata.from_tiles(tiles)
+    print_basemodel(em_meta)
+
+    def print_slice_variations():
+        pyramids: dict[int, Pyramid] = {}
+        tiles.sort(key=operator.attrgetter("slice"))
+        for slice, stiles in groupby(tiles, lambda t: t.slice):
+            pyramids[slice] = Pyramid.build(list(stiles))
+
+        min_extent: tuple[int, int, int, int] = (maxsize, maxsize, maxsize, maxsize)
+        min_extent_slice: int = -1
+
+        max_extent: tuple[int, int, int, int] = (-1, -1, -1, -1)
+        max_extent_slice: int = -1
+
+        min_resolution: tuple[int, int] = (maxsize, maxsize)
+        min_resolution_slice: int = -1
+
+        max_resolution: tuple[int, int] = (-1, -1)
+        max_resolution_slice: int = -1
+
+        for slice, pyr in pyramids.items():
+            extent = pyr.extent[2:]
+            if extent < min_extent:
+                min_extent = pyr.extent
+                min_extent_slice = slice
+            elif extent > max_extent:
+                max_extent = pyr.extent
+                max_extent_slice = slice
+
+            resolution = pyr.resolution
+            if resolution < min_resolution:
+                min_resolution = resolution
+                min_resolution_slice = slice
+            elif resolution > max_resolution:
+                max_resolution = resolution
+                max_resolution_slice = slice
+
+        @dataclass
+        class PyramidVariationsStats:
+            min_extent: tuple[int, int, int, int]
+            min_extent_slice: int
+            max_extent: tuple[int, int, int, int]
+            max_extent_slice: int
+
+            min_resolution: tuple[int, int]
+            min_resolution_slice: int
+            max_resolution: tuple[int, int]
+            max_resolution_slice: int
+
+        print_dataclass(
+            PyramidVariationsStats(
+                min_extent=min_extent,
+                min_extent_slice=min_extent_slice,
+                max_extent=max_extent,
+                max_extent_slice=max_extent_slice,
+                min_resolution=min_resolution,
+                min_resolution_slice=min_resolution_slice,
+                max_resolution=max_resolution,
+                max_resolution_slice=max_resolution_slice,
+            )
+        )
+
+    print("~~~~~ Deviation")
+
+    print_slice_variations()
+
+    print("\n====== Pyramid metadata =======")
+
+    pyramid = Pyramid.build(tiles)
+
+    def validate_pyramid(pyramid: Pyramid):
+        for lvl, grid in pyramid.levels.items():
+            for tile in grid:
+                if tile is None:
+                    continue
+                assert tile.zoom == lvl
+
+        assert pyramid.maxzoom == min(pyramid.levels.keys())
+        assert pyramid.minzoom == max(pyramid.levels.keys())
+
+    validate_pyramid(pyramid)
+    print_dataclass(pyramid, exclude={"levels"})
+
+    print("\n======= Pyramid Levels ========")
+
+    for lvl, grid in pyramid.levels.items():
+        print(f"~~~{lvl}~~~")
+        print_dataclass(grid, exclude={"matrix"})

--- a/ingestion/ingestion/em_metadata.py
+++ b/ingestion/ingestion/em_metadata.py
@@ -19,7 +19,7 @@ class Tile:
 
     @property
     @lru_cache(1)
-    def size(self) -> tuple[int, int]:
+    def size(self) -> tuple[int, int]:  # (w, h)
         with Image.open(self.path) as img:
             return img.size
 
@@ -30,7 +30,7 @@ class TileGrid:
 
     zoom: int
     size: tuple[int, int]  # rows and columns
-    matrix: list[list[Tile | None]]  # tiles organized in a matrix
+    matrix: list[list[Tile | None]]  # tiles organized in a matrix [row][col]
 
     @staticmethod
     def _matrix_size(tiles: list[Tile]) -> tuple[int, int]:
@@ -41,7 +41,7 @@ class TileGrid:
                 maxx = x
             if y > maxy:
                 maxy = y
-        return (maxx + 1, maxy + 1)
+        return (maxy + 1, maxx + 1)
 
     @staticmethod
     def _are_tiles_size_eq(tiles: list[Tile]) -> bool:
@@ -73,30 +73,30 @@ class TileGrid:
         """Resolution of the grid in pixels"""
         n_rows, n_cols = self.size
         width, height = self.tile_dimensions
-        return (height * n_rows, width * n_cols)
+        return (width * n_cols, height * n_rows)
 
     @classmethod
     def from_tiles(cls, tiles: list[Tile]) -> TileGrid:
         if len(tiles) == 0:
             raise Exception("tiles can not be an empty list")
 
-        size = cls._matrix_size(tiles)
+        n_rows, n_cols = cls._matrix_size(tiles)
         # It's not necessary to test all the tiles size in a same slice
         # We consider that they have the same size
         # assert cls._are_tiles_size_eq(tiles)
 
         zoom = tiles[0].zoom
 
-        matrix: list[list[Tile | None]] = [[None] * size[1] for _ in range(size[0])]
+        matrix: list[list[Tile | None]] = [[None] * n_cols for _ in range(n_rows)]
         for tile in tiles:
             x, y = tile.position
-            matrix[x][y] = tile
+            matrix[y][x] = tile
 
-        return cls(zoom=zoom, size=size, matrix=matrix)
+        return cls(zoom=zoom, size=(n_rows, n_cols), matrix=matrix)
 
 
 @dataclass
-class Piramid:
+class Pyramid:
     """A piramid structure with a tile matrix for each zoom level"""
 
     levels: dict[int, TileGrid]
@@ -107,10 +107,8 @@ class Piramid:
     @property
     def extent(self) -> tuple[int, int, int, int]:
         maxX, maxY = (0, 0)
-        for lvl in self.levels.values():
-            if lvl is not None:
-                maxX, maxY = lvl.resolution
-                break
+        if self.zooms:
+            maxX, maxY = self.levels[self.maxzoom].resolution
 
         # TODO: this may be optimized further to excluse black tiles from being requested
         minX, minY = (0, 0)
@@ -123,23 +121,36 @@ class Piramid:
     @property
     def minzoom(self) -> int:
         """Minimum zoom value that exits in the piramid"""
-        return min(self.zooms)
+        return max(self.zooms)
 
     @property
     def maxzoom(self) -> int:
         """Maximum zoom value that exits in the piramid"""
-        return max(self.zooms)
+        return min(self.zooms)
 
     @property
     def tile_dimensions(self) -> tuple[int, int]:
         # it assumes that tile size is the same across zoom levels
         zooms = self.zooms
-        if zooms == 0:
+        if len(zooms) == 0:
             return (0, 0)  # no data
         return self.levels[zooms[0]].tile_dimensions
 
+    @property
+    def resolution(self) -> tuple[int, int]:
+        """Resolution of the maxzoom tiles"""
+        zooms = self.zooms
+        if len(zooms) == 0:
+            return (0, 0)  # no data
+
+        tile_grid = self.levels[self.maxzoom]
+        [w, h] = self.tile_dimensions
+        [r, c] = tile_grid.size
+
+        return (c * w, r * h)
+
     @classmethod
-    def build(cls, tiles: list[Tile]) -> Piramid:
+    def build(cls, tiles: list[Tile]) -> Pyramid:
         levels: dict[int, TileGrid] = {}
 
         tiles.sort(key=operator.attrgetter("zoom"))  # groupby expects things sorted
@@ -163,6 +174,7 @@ class EMMetadata(BaseModel):
     minzoom: int
     maxzoom: int
     tile_size: tuple[int, int]
+    resolution: tuple[int, int]
     slices: list[int]
 
     @classmethod
@@ -173,7 +185,7 @@ class EMMetadata(BaseModel):
         tiles.sort(key=operator.attrgetter("slice"))  # groupby expects things sorted
         previous_piramid = None
         for slice, stiles in groupby(tiles, lambda t: t.slice):
-            piramid = Piramid.build(list(stiles))
+            piramid = Pyramid.build(list(stiles))
             available_slices.append(slice)
             assert (
                 not previous_piramid
@@ -187,6 +199,7 @@ class EMMetadata(BaseModel):
             minzoom=piramid.minzoom,
             maxzoom=piramid.maxzoom,
             tile_size=piramid.tile_dimensions,
+            resolution=piramid.resolution,
         )
 
     def merge(self, emm2: EMMetadata) -> EMMetadata:
@@ -209,6 +222,7 @@ class EMMetadata(BaseModel):
             minzoom=self.minzoom,
             maxzoom=self.maxzoom,
             tile_size=self.tile_size,
+            resolution=self.resolution,
         )
 
 

--- a/ingestion/ingestion/em_metadata.py
+++ b/ingestion/ingestion/em_metadata.py
@@ -335,7 +335,7 @@ if __name__ == "__main__":
             if extent < min_extent:
                 min_extent = pyr.extent
                 min_extent_slice = slice
-            elif extent > max_extent:
+            if extent > max_extent:
                 max_extent = pyr.extent
                 max_extent_slice = slice
 
@@ -343,7 +343,7 @@ if __name__ == "__main__":
             if resolution < min_resolution:
                 min_resolution = resolution
                 min_resolution_slice = slice
-            elif resolution > max_resolution:
+            if resolution > max_resolution:
                 max_resolution = resolution
                 max_resolution_slice = slice
 

--- a/ingestion/ingestion/storage/blob.py
+++ b/ingestion/ingestion/storage/blob.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from collections import Counter
+
 import re
+from collections import Counter
 from pathlib import Path
 
 from ingestion.em_metadata import Tile

--- a/ingestion/tests/fixtures/em-tiles/metadata.json
+++ b/ingestion/tests/fixtures/em-tiles/metadata.json
@@ -1,1 +1,1 @@
-{"number_slices":1,"slice_range":[209,209],"minzoom":5,"maxzoom":4,"tile_size":[512,512],"resolution":[2048,1536],"slices":[209]}
+{"number_slices":1,"slice_range":[209,209],"minzoom":4,"maxzoom":5,"tile_size":[512,512],"resolution":[1024,1024],"slices":[209]}

--- a/ingestion/tests/fixtures/em-tiles/metadata.json
+++ b/ingestion/tests/fixtures/em-tiles/metadata.json
@@ -1,1 +1,1 @@
-{"number_slices":1,"slice_range":[209,209],"minzoom":4,"maxzoom":5,"tile_size":[512,512],"slices":[209]}
+{"number_slices":1,"slice_range":[209,209],"minzoom":5,"maxzoom":4,"tile_size":[512,512],"resolution":[2048,1536],"slices":[209]}

--- a/ingestion/tests/test_em_metadata.py
+++ b/ingestion/tests/test_em_metadata.py
@@ -285,7 +285,7 @@ def test__tile_matrix_missing_column(slices_dir_fixture: Path):
     assert grid.resolution == (512, 1024)
 
 
-def test__piramid(
+def test__pyramid(
     slices_dir_fixture: Path,
     slice209_tilegrid_zoom5: TileGrid,
     slice209_tilegrid_zoom4: TileGrid,
@@ -295,21 +295,22 @@ def test__piramid(
         for tile_path in (slices_dir_fixture / "209").glob(TILE_GLOB)
     )
 
-    expected_piramid = Pyramid(
+    expected_pyramid = Pyramid(
         levels={
             4: slice209_tilegrid_zoom4,
             5: slice209_tilegrid_zoom5,
         }
     )
 
-    piramid = Pyramid.build(tiles)
+    pyramid = Pyramid.build(tiles)
 
-    assert piramid == expected_piramid
-    assert piramid.extent == expected_piramid.extent == (0, 0, 2048, 1536)
-    assert piramid.minzoom == expected_piramid.minzoom == 5
-    assert piramid.maxzoom == expected_piramid.maxzoom == 4
-    assert piramid.tile_dimensions == expected_piramid.tile_dimensions == (512, 512)
-    assert piramid.resolution == expected_piramid.resolution == (2048, 1536)
+    assert pyramid == expected_pyramid
+    assert pyramid.extent == expected_pyramid.extent == (0, 0, 2048, 1536)
+    assert pyramid.minzoom == expected_pyramid.minzoom == 4
+    assert pyramid.maxzoom == expected_pyramid.maxzoom == 5
+    assert pyramid.tile_dimensions == expected_pyramid.tile_dimensions == (512, 512)
+    # assert pyramid.resolution == expected_pyramid.resolution == (2048, 1536)
+    assert pyramid.resolution == expected_pyramid.resolution == (1024, 1024)
 
 
 def test__em_metadata_merge():

--- a/ingestion/tests/test_em_metadata.py
+++ b/ingestion/tests/test_em_metadata.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from ingestion.em_metadata import EMMetadata, Piramid, SliceMetadata, Tile, TileGrid
+from ingestion.em_metadata import EMMetadata, Pyramid, Tile, TileGrid
 from ingestion.storage.filesystem import TILE_GLOB, extract_tile_metadata
 
 
@@ -31,17 +31,17 @@ def slice209_tilegrid_zoom5(slices_dir_fixture: Path) -> TileGrid:
                     slice=209,
                 ),
                 Tile(
-                    position=(0, 1),
+                    position=(1, 0),
                     zoom=5,
-                    path=dir_path / "1_0_5.jpg",
+                    path=dir_path / "0_1_5.jpg",
                     slice=209,
                 ),
             ],
             [
                 Tile(
-                    position=(1, 0),
+                    position=(0, 1),
                     zoom=5,
-                    path=dir_path / "0_1_5.jpg",
+                    path=dir_path / "1_0_5.jpg",
                     slice=209,
                 ),
                 Tile(
@@ -63,10 +63,10 @@ def slice209_tilegrid_zoom4(slices_dir_fixture: Path) -> TileGrid:
     dir_path = slices_dir_fixture / "209"
     return TileGrid(
         zoom=4,
-        size=(4, 3),
+        size=(3, 4),
         matrix=[
-            [None, None, None],
             [
+                None,
                 Tile(
                     position=(1, 0),
                     zoom=4,
@@ -74,23 +74,24 @@ def slice209_tilegrid_zoom4(slices_dir_fixture: Path) -> TileGrid:
                     slice=209,
                 ),
                 Tile(
-                    position=(1, 1),
+                    position=(2, 0),
                     zoom=4,
-                    path=dir_path / "1_1_4.jpg",
+                    path=dir_path / "0_2_4.jpg",
                     slice=209,
                 ),
                 Tile(
-                    position=(1, 2),
+                    position=(3, 0),
                     zoom=4,
-                    path=dir_path / "2_1_4.jpg",
+                    path=dir_path / "0_3_4.jpg",
                     slice=209,
                 ),
             ],
             [
+                None,
                 Tile(
-                    position=(2, 0),
+                    position=(1, 1),
                     zoom=4,
-                    path=dir_path / "0_2_4.jpg",
+                    path=dir_path / "1_1_4.jpg",
                     slice=209,
                 ),
                 Tile(
@@ -100,23 +101,24 @@ def slice209_tilegrid_zoom4(slices_dir_fixture: Path) -> TileGrid:
                     slice=209,
                 ),
                 Tile(
-                    position=(2, 2),
+                    position=(3, 1),
                     zoom=4,
-                    path=dir_path / "2_2_4.jpg",
+                    path=dir_path / "1_3_4.jpg",
                     slice=209,
                 ),
             ],
             [
+                None,
                 Tile(
-                    position=(3, 0),
+                    position=(1, 2),
                     zoom=4,
-                    path=dir_path / "0_3_4.jpg",
+                    path=dir_path / "2_1_4.jpg",
                     slice=209,
                 ),
                 Tile(
-                    position=(3, 1),
+                    position=(2, 2),
                     zoom=4,
-                    path=dir_path / "1_3_4.jpg",
+                    path=dir_path / "2_2_4.jpg",
                     slice=209,
                 ),
                 Tile(
@@ -169,15 +171,15 @@ def test__tile_matrix_with_holes(slices_dir_fixture: Path):
                     path=slice_209_path / "0_0_5.jpg",
                     slice=209,
                 ),
-                None,  # the hole
-            ],
-            [
                 Tile(
                     position=(1, 0),
                     zoom=5,
                     path=slice_209_path / "0_1_5.jpg",
                     slice=209,
                 ),
+            ],
+            [
+                None,  # the hole
                 Tile(
                     position=(1, 1),
                     zoom=5,
@@ -209,7 +211,7 @@ def test__tile_matrix_missing_row(slices_dir_fixture: Path):
     slice_209_path = slices_dir_fixture / "209"
     expected_matrix_zoom_5 = TileGrid(
         zoom=5,
-        size=(2, 1),
+        size=(1, 2),
         matrix=[
             [
                 Tile(
@@ -218,15 +220,13 @@ def test__tile_matrix_missing_row(slices_dir_fixture: Path):
                     path=slice_209_path / "0_0_5.jpg",
                     slice=209,
                 ),
-            ],
-            [
                 Tile(
                     position=(1, 0),
                     zoom=5,
                     path=slice_209_path / "0_1_5.jpg",
                     slice=209,
                 ),
-            ],
+            ]
         ],
     )
 
@@ -249,7 +249,7 @@ def test__tile_matrix_missing_column(slices_dir_fixture: Path):
     slice_209_path = slices_dir_fixture / "209"
     expected_matrix_zoom_5 = TileGrid(
         zoom=5,
-        size=(1, 2),
+        size=(2, 1),
         matrix=[
             [
                 Tile(
@@ -258,13 +258,15 @@ def test__tile_matrix_missing_column(slices_dir_fixture: Path):
                     path=slice_209_path / "0_0_5.jpg",
                     slice=209,
                 ),
+            ],
+            [
                 Tile(
                     position=(0, 1),
                     zoom=5,
                     path=slice_209_path / "1_0_5.jpg",
                     slice=209,
                 ),
-            ]
+            ],
         ],
     )
 
@@ -293,20 +295,21 @@ def test__piramid(
         for tile_path in (slices_dir_fixture / "209").glob(TILE_GLOB)
     )
 
-    expected_piramid = Piramid(
+    expected_piramid = Pyramid(
         levels={
             4: slice209_tilegrid_zoom4,
             5: slice209_tilegrid_zoom5,
         }
     )
 
-    piramid = Piramid.build(tiles)
+    piramid = Pyramid.build(tiles)
 
     assert piramid == expected_piramid
-    assert piramid.extent == expected_piramid.extent
-    assert piramid.minzoom == expected_piramid.minzoom
-    assert piramid.maxzoom == expected_piramid.maxzoom
-    assert piramid.tile_dimensions == expected_piramid.tile_dimensions
+    assert piramid.extent == expected_piramid.extent == (0, 0, 2048, 1536)
+    assert piramid.minzoom == expected_piramid.minzoom == 5
+    assert piramid.maxzoom == expected_piramid.maxzoom == 4
+    assert piramid.tile_dimensions == expected_piramid.tile_dimensions == (512, 512)
+    assert piramid.resolution == expected_piramid.resolution == (2048, 1536)
 
 
 def test__em_metadata_merge():
@@ -316,6 +319,7 @@ def test__em_metadata_merge():
         minzoom=1,
         maxzoom=5,
         tile_size=(512, 512),
+        resolution=(512, 512),  # TODO: make better tests for resolution
         slices=[1, 2, 3],
     )
     mt2 = EMMetadata(
@@ -325,6 +329,7 @@ def test__em_metadata_merge():
         minzoom=1,
         maxzoom=5,
         tile_size=(512, 512),
+        resolution=(512, 512),
     )
 
     expected_merge = EMMetadata(
@@ -334,6 +339,7 @@ def test__em_metadata_merge():
         minzoom=1,
         maxzoom=5,
         tile_size=(512, 512),
+        resolution=(512, 512),
     )
 
     assert mt1.merge(mt2) == expected_merge


### PR DESCRIPTION
Currently, the EM viewer assumes that segmentation information will be present. The basic information for the segmentation impacts the “extent” of the EM viewer, which is used to computer properly the size of the final canvas and ensure that the positions of the polygons when a segmentation is displayed is there.

There is some dataset that might not have a segmentation, we need to tackle those cases.

Various aspect of the software need to be modified:

- [x] the ingestion needs to be modified to include the full image size in the metadata for the EM files
    - [x] change the code to include the EM tiles resolution in the metadata
    - [x] update the metadata in the bucket
- [x] this information needs to be written in the DB when the files are ingested (all the glue is here and should be working, only the “write the final image size” part is not in the tool that will ingest the data)
- [x] in the frontend, we need to modify the final size of the map following this idea: if there is a segmentation, we use this size, otherwise, we use the image size of the EM data
- [x] we need to create the layers and rings for the segmentation and the synapse segmentation only if there is some

**Changes**:

1. Datasets API now returns an extra field `emData. maxResolution` with the maximum resolution of the EM tiles
2. `maxResolution` is calculated during dataset ingestion and pushed in to the bucket
3. `maxResolution` is saved in to the DB when the files are ingested
4. If no EM data is available, it renders a `NoEMData` component instead of the EM viewer [^1]
5. If no segmentation data is available, the EM viewer will take on the EM data extent (`maxResolution`) in the EM viewer (**something is not working correctly and needs to be understood why**)
6. Neuron and synapses segmentations are only added to the EM viewer if the data is available
7. CLI utility to inspect EM tiles metadata: `python -m ingestion.em_metadata ../data/witvliet_2020_7/em`
8. Fix some pyramid related code and tests

[^1]: ![image](https://github.com/user-attachments/assets/a4f1c160-164e-4119-9a91-318bef47e1ee)


